### PR TITLE
Add questionnaire versioning for Sync Sessions and normalized intent categories

### DIFF
--- a/src/app/api/survey/route.ts
+++ b/src/app/api/survey/route.ts
@@ -67,7 +67,11 @@ export async function POST(request: Request) {
     }
   }
 
-  const mapped = mapAnswersToSurveyResponsePayload(body.answers);
+  const mapped = mapAnswersToSurveyResponsePayload({
+    answers: body.answers,
+    sessionType: body.sessionType,
+    questionnaireVersion: body.questionnaireVersion,
+  });
   if (!mapped.ok) {
     return NextResponse.json(
       {
@@ -89,7 +93,8 @@ export async function POST(request: Request) {
 
     const surveyResponse = createSurveyResponse({
       attendee_id: attendee.id,
-      ...mapped.data,
+      ...mapped.data.surveyResponse,
+      categories: mapped.data.categories,
     });
 
     return NextResponse.json({

--- a/src/components/DataVisualization/shared/useVisualizationData.ts
+++ b/src/components/DataVisualization/shared/useVisualizationData.ts
@@ -27,6 +27,8 @@ const mockData: SurveyRow[] = [
   {
     id: 'mock-1',
     attendee_id: 'mock-attendee-1',
+    session_type: 'profile',
+    questionnaire_version: 'v1',
     tenure_years: 5,
     learning_style: 'visual',
     shaped_by: 'mentor',
@@ -48,6 +50,8 @@ const mockData: SurveyRow[] = [
   {
     id: 'mock-2',
     attendee_id: 'mock-attendee-2',
+    session_type: 'profile',
+    questionnaire_version: 'v1',
     tenure_years: 10,
     learning_style: 'auditory',
     shaped_by: 'challenge',
@@ -69,6 +73,8 @@ const mockData: SurveyRow[] = [
   {
     id: 'mock-3',
     attendee_id: 'mock-attendee-3',
+    session_type: 'profile',
+    questionnaire_version: 'v1',
     tenure_years: 15,
     learning_style: 'kinesthetic',
     shaped_by: 'success',

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -38,6 +38,8 @@ function runBootstrap(sqlite: Database.Database) {
     CREATE TABLE IF NOT EXISTS survey_responses (
       id TEXT PRIMARY KEY NOT NULL,
       attendee_id TEXT NOT NULL REFERENCES attendees(id) ON DELETE CASCADE,
+      session_type TEXT NOT NULL DEFAULT 'profile',
+      questionnaire_version TEXT NOT NULL DEFAULT 'v1',
       tenure_years INTEGER,
       learning_style TEXT,
       shaped_by TEXT,
@@ -52,6 +54,18 @@ function runBootstrap(sqlite: Database.Database) {
     );
     CREATE INDEX IF NOT EXISTS idx_survey_responses_attendee_id ON survey_responses(attendee_id);
     CREATE INDEX IF NOT EXISTS idx_survey_responses_created_at ON survey_responses(created_at);
+
+    CREATE TABLE IF NOT EXISTS survey_response_intent_categories (
+      id TEXT PRIMARY KEY NOT NULL,
+      response_id TEXT NOT NULL REFERENCES survey_responses(id) ON DELETE CASCADE,
+      category TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      UNIQUE(response_id, category)
+    );
+    CREATE INDEX IF NOT EXISTS idx_survey_response_intent_categories_response_id ON survey_response_intent_categories(response_id);
+    CREATE INDEX IF NOT EXISTS idx_survey_response_intent_categories_category ON survey_response_intent_categories(category);
 
     CREATE TABLE IF NOT EXISTS peak_performance_definitions (
       id TEXT PRIMARY KEY NOT NULL,
@@ -147,6 +161,17 @@ function runBootstrap(sqlite: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_study_reviews_card_id ON study_reviews(card_id);
     CREATE INDEX IF NOT EXISTS idx_study_reviews_reviewed_at ON study_reviews(reviewed_at DESC);
   `);
+
+  const surveyColumns = sqlite
+    .prepare(`PRAGMA table_info(survey_responses)`)
+    .all() as { name: string }[];
+  const surveyColumnSet = new Set(surveyColumns.map((c) => c.name));
+  if (!surveyColumnSet.has('session_type')) {
+    sqlite.exec(`ALTER TABLE survey_responses ADD COLUMN session_type TEXT NOT NULL DEFAULT 'profile';`);
+  }
+  if (!surveyColumnSet.has('questionnaire_version')) {
+    sqlite.exec(`ALTER TABLE survey_responses ADD COLUMN questionnaire_version TEXT NOT NULL DEFAULT 'v1';`);
+  }
 
   const now = new Date().toISOString();
   const seed = sqlite.prepare(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -21,6 +21,8 @@ export const surveyResponses = sqliteTable(
     attendeeId: text('attendee_id')
       .notNull()
       .references(() => attendees.id, { onDelete: 'cascade' }),
+    sessionType: text('session_type').notNull().default('profile'),
+    questionnaireVersion: text('questionnaire_version').notNull().default('v1'),
     tenureYears: integer('tenure_years'),
     learningStyle: text('learning_style'),
     shapedBy: text('shaped_by'),
@@ -38,6 +40,28 @@ export const surveyResponses = sqliteTable(
   (t) => [
     index('idx_survey_responses_attendee_id').on(t.attendeeId),
     index('idx_survey_responses_created_at').on(t.createdAt),
+  ]
+);
+
+
+export const surveyResponseIntentCategories = sqliteTable(
+  'survey_response_intent_categories',
+  {
+    id: text('id').primaryKey(),
+    responseId: text('response_id')
+      .notNull()
+      .references(() => surveyResponses.id, { onDelete: 'cascade' }),
+    category: text('category', {
+      enum: ['questions', 'concerns', 'needs', 'accomplishments', 'stats', 'constraints', 'signals'],
+    }).notNull(),
+    content: text('content').notNull(),
+    createdAt: text('created_at').notNull(),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (t) => [
+    index('idx_survey_response_intent_categories_response_id').on(t.responseId),
+    index('idx_survey_response_intent_categories_category').on(t.category),
+    uniqueIndex('survey_response_intent_categories_response_category_unique').on(t.responseId, t.category),
   ]
 );
 

--- a/src/lib/dataAdapter.ts
+++ b/src/lib/dataAdapter.ts
@@ -181,6 +181,8 @@ export const convertAppToDBResponse = (appResponse: AppSurveyResponse): DBSurvey
     attendee_id: `a${appResponse.id.split('_')[1]}`,
     created_at: appResponse.created_at,
     updated_at: appResponse.created_at,
+    session_type: 'profile',
+    questionnaire_version: 'v1',
     attendee: {
       first_name: firstName,
       last_name: isAnonymous ? null : lastName,

--- a/src/lib/hooks/useSyncSessionForm.ts
+++ b/src/lib/hooks/useSyncSessionForm.ts
@@ -41,6 +41,8 @@ function buildSyncSessionPostBody(formData: SyncSessionFormData) {
     lastName,
     email: formData.is_anonymous ? '' : formData.email ?? '',
     isAnonymous: formData.is_anonymous,
+    sessionType: 'profile',
+    questionnaireVersion: 'v1',
     answers,
   };
 }

--- a/src/lib/storage/repositories/survey.ts
+++ b/src/lib/storage/repositories/survey.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from 'crypto';
 import { and, desc, eq } from 'drizzle-orm';
-import { attendees, moderation, peakPerformanceDefinitions, surveyResponses } from '@/db/schema';
+import {
+  attendees,
+  moderation,
+  peakPerformanceDefinitions,
+  surveyResponseIntentCategories,
+  surveyResponses,
+} from '@/db/schema';
 import { getDb, getSqlite } from '@/db/client';
 import type {
   AttendeeRow,
@@ -8,6 +14,7 @@ import type {
   ModerationRow,
   ModerationStatus,
   MotivationType,
+  IntentCategory,
   PeakPerformanceDefinitionRow,
   PeakPerformanceType,
   ShapedBy,
@@ -35,6 +42,8 @@ function rowToSurvey(row: typeof surveyResponses.$inferSelect): SurveyResponseRo
   return {
     id: row.id,
     attendee_id: row.attendeeId,
+    session_type: row.sessionType as SurveyResponseRow['session_type'],
+    questionnaire_version: row.questionnaireVersion as SurveyResponseRow['questionnaire_version'],
     tenure_years: row.tenureYears,
     learning_style: row.learningStyle as LearningStyle | null,
     shaped_by: row.shapedBy as ShapedBy | null,
@@ -108,6 +117,8 @@ export function createAttendee(data: {
 
 export function createSurveyResponse(data: {
   attendee_id: string;
+  session_type?: SurveyResponseRow['session_type'];
+  questionnaire_version?: SurveyResponseRow['questionnaire_version'];
   tenure_years?: number;
   learning_style?: LearningStyle | null;
   shaped_by?: ShapedBy | null;
@@ -115,6 +126,7 @@ export function createSurveyResponse(data: {
   motivation?: MotivationType | null;
   unique_quality?: string;
   test_data?: boolean;
+  categories?: { category: IntentCategory; content: string }[];
 }): SurveyResponseRow {
   const db = getDb();
   const id = randomUUID();
@@ -123,6 +135,8 @@ export function createSurveyResponse(data: {
     .values({
       id,
       attendeeId: data.attendee_id,
+      sessionType: data.session_type ?? 'profile',
+      questionnaireVersion: data.questionnaire_version ?? 'v1',
       tenureYears: data.tenure_years ?? null,
       learningStyle: data.learning_style ?? null,
       shapedBy: data.shaped_by ?? null,
@@ -136,6 +150,26 @@ export function createSurveyResponse(data: {
       updatedAt: ts,
     })
     .run();
+
+  if (data.categories && data.categories.length > 0) {
+    for (const category of data.categories) {
+      db.insert(surveyResponseIntentCategories)
+        .values({
+          id: randomUUID(),
+          responseId: id,
+          category: category.category,
+          content: category.content,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+        .onConflictDoUpdate({
+          target: [surveyResponseIntentCategories.responseId, surveyResponseIntentCategories.category],
+          set: { content: category.content, updatedAt: ts },
+        })
+        .run();
+    }
+  }
+
   const row = db.select().from(surveyResponses).where(eq(surveyResponses.id, id)).get();
   if (!row) throw new Error('Survey response insert failed');
   return rowToSurvey(row);
@@ -189,6 +223,11 @@ export function getModerationQueue(): ModerationQueueRow[] {
     const sr: SurveyResponseRow = {
       id,
       attendee_id: String(raw.attendee_id),
+      session_type: raw.session_type == null ? 'profile' : (String(raw.session_type) as SurveyResponseRow['session_type']),
+      questionnaire_version:
+        raw.questionnaire_version == null
+          ? 'v1'
+          : (String(raw.questionnaire_version) as SurveyResponseRow['questionnaire_version']),
       tenure_years: raw.tenure_years == null ? null : Number(raw.tenure_years),
       learning_style: raw.learning_style as LearningStyle | null,
       shaped_by: raw.shaped_by as ShapedBy | null,

--- a/src/lib/survey/mapAnswersToSurveyResponse.ts
+++ b/src/lib/survey/mapAnswersToSurveyResponse.ts
@@ -1,22 +1,25 @@
 import { z } from 'zod';
 
 import type { SurveyResponseRow } from '@/lib/types/database';
-import type { SurveyPostBody } from './schemas';
 
 type LearningStyle = NonNullable<SurveyResponseRow['learning_style']>;
 type ShapedBy = NonNullable<SurveyResponseRow['shaped_by']>;
 type PeakPerformance = NonNullable<SurveyResponseRow['peak_performance']>;
 type Motivation = NonNullable<SurveyResponseRow['motivation']>;
 
-/** Payload for createSurveyResponse (excluding attendee_id). */
-export type SurveyResponseFields = {
-  tenure_years?: number;
-  learning_style?: LearningStyle;
-  shaped_by?: ShapedBy;
-  peak_performance?: PeakPerformance;
-  motivation?: Motivation;
-  unique_quality?: string;
-};
+export const INTENT_CATEGORIES = [
+  'questions',
+  'concerns',
+  'needs',
+  'accomplishments',
+  'stats',
+  'constraints',
+  'signals',
+] as const;
+
+export type IntentCategory = (typeof INTENT_CATEGORIES)[number];
+export type SessionType = string;
+export type QuestionnaireVersion = string;
 
 const LEARNING_STYLE = z.enum(['visual', 'auditory', 'kinesthetic', 'reading_writing']);
 const SHAPED_BY = z.enum(['mentor', 'challenge', 'failure', 'success', 'team', 'other']);
@@ -30,38 +33,53 @@ const PEAK_PERFORMANCE = z.enum([
 ]);
 const MOTIVATION = z.enum(['impact', 'growth', 'recognition', 'autonomy', 'purpose']);
 
-const KNOWN_QUESTION_IDS = new Set([
+/** Payload for createSurveyResponse (excluding attendee_id). */
+export type SurveyResponseFields = {
+  session_type: SessionType;
+  questionnaire_version: QuestionnaireVersion;
+  tenure_years?: number;
+  learning_style?: LearningStyle;
+  shaped_by?: ShapedBy;
+  peak_performance?: PeakPerformance;
+  motivation?: Motivation;
+  unique_quality?: string;
+};
+
+export type SurveyAnswerRow = {
+  questionId: string;
+  answer: string;
+};
+
+export type IntentCategoryPayload = {
+  category: IntentCategory;
+  content: string;
+};
+
+type QuestionnaireMapper = {
+  knownQuestionIds: ReadonlySet<string>;
+  map: (answersById: Map<string, string>) =>
+    | { ok: true; data: Omit<SurveyResponseFields, 'session_type' | 'questionnaire_version'>; categories: IntentCategoryPayload[] }
+    | { ok: false; error: MapAnswersError };
+};
+
+const profileV1QuestionIds = new Set([
   'tenure_years',
   'learning_style',
   'shaped_by',
   'peak_performance',
   'motivation',
   'unique_quality',
+  ...INTENT_CATEGORIES,
 ]);
 
-export type MapAnswersError = {
-  message: string;
-  field?: string;
-};
+function mapProfileV1(answersById: Map<string, string>) {
+  const out: Omit<SurveyResponseFields, 'session_type' | 'questionnaire_version'> = {};
+  const categories: IntentCategoryPayload[] = [];
 
-/**
- * Maps validated POST body answers to survey_responses columns.
- * Duplicate questionId: last wins.
- */
-export function mapAnswersToSurveyResponsePayload(
-  answers: SurveyPostBody['answers']
-): { ok: true; data: SurveyResponseFields } | { ok: false; error: MapAnswersError } {
-  const byId = new Map<string, string>();
-  for (const row of answers) {
-    byId.set(row.questionId, row.answer);
-  }
-
-  const out: SurveyResponseFields = {};
-
-  for (const [questionId, raw] of Array.from(byId.entries())) {
-    if (!KNOWN_QUESTION_IDS.has(questionId)) {
+  for (const [questionId, raw] of Array.from(answersById.entries())) {
+    if (!profileV1QuestionIds.has(questionId)) {
       return {
-        ok: false,
+        ok: false as const,
         error: { message: `Unknown questionId: ${questionId}`, field: questionId },
       };
     }
@@ -71,12 +89,17 @@ export function mapAnswersToSurveyResponsePayload(
       continue;
     }
 
+    if ((INTENT_CATEGORIES as readonly string[]).includes(questionId)) {
+      categories.push({ category: questionId as IntentCategory, content: trimmed });
+      continue;
+    }
+
     switch (questionId) {
       case 'tenure_years': {
         const n = Number(trimmed);
         if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0 || n > 80) {
           return {
-            ok: false,
+            ok: false as const,
             error: {
               message: 'tenure_years must be an integer from 0 to 80',
               field: 'tenure_years',
@@ -90,7 +113,7 @@ export function mapAnswersToSurveyResponsePayload(
         const p = LEARNING_STYLE.safeParse(trimmed);
         if (!p.success) {
           return {
-            ok: false,
+            ok: false as const,
             error: { message: 'Invalid learning_style value', field: 'learning_style' },
           };
         }
@@ -101,7 +124,7 @@ export function mapAnswersToSurveyResponsePayload(
         const p = SHAPED_BY.safeParse(trimmed);
         if (!p.success) {
           return {
-            ok: false,
+            ok: false as const,
             error: { message: 'Invalid shaped_by value', field: 'shaped_by' },
           };
         }
@@ -112,7 +135,7 @@ export function mapAnswersToSurveyResponsePayload(
         const p = PEAK_PERFORMANCE.safeParse(trimmed);
         if (!p.success) {
           return {
-            ok: false,
+            ok: false as const,
             error: { message: 'Invalid peak_performance value', field: 'peak_performance' },
           };
         }
@@ -123,7 +146,7 @@ export function mapAnswersToSurveyResponsePayload(
         const p = MOTIVATION.safeParse(trimmed);
         if (!p.success) {
           return {
-            ok: false,
+            ok: false as const,
             error: { message: 'Invalid motivation value', field: 'motivation' },
           };
         }
@@ -133,7 +156,7 @@ export function mapAnswersToSurveyResponsePayload(
       case 'unique_quality': {
         if (trimmed.length > 4000) {
           return {
-            ok: false,
+            ok: false as const,
             error: { message: 'unique_quality exceeds max length', field: 'unique_quality' },
           };
         }
@@ -145,5 +168,81 @@ export function mapAnswersToSurveyResponsePayload(
     }
   }
 
-  return { ok: true, data: out };
+  return { ok: true as const, data: out, categories };
+}
+
+const QUESTIONNAIRE_MAPPERS: Record<string, Record<string, QuestionnaireMapper>> = {
+  profile: {
+    v1: {
+      knownQuestionIds: profileV1QuestionIds,
+      map: mapProfileV1,
+    },
+  },
+};
+
+export type MapAnswersError = {
+  message: string;
+  field?: string;
+};
+
+export type MapAnswersSuccess = {
+  surveyResponse: SurveyResponseFields;
+  categories: IntentCategoryPayload[];
+};
+
+export function hasQuestionnaireMapper(sessionType: string, questionnaireVersion: string): boolean {
+  return Boolean(
+    QUESTIONNAIRE_MAPPERS[sessionType as SessionType]?.[
+      questionnaireVersion as QuestionnaireVersion
+    ]
+  );
+}
+
+/**
+ * Maps validated POST body answers to survey_responses columns.
+ * Duplicate questionId: last wins.
+ */
+export function mapAnswersToSurveyResponsePayload(args: {
+  answers: SurveyAnswerRow[];
+  sessionType?: SessionType;
+  questionnaireVersion?: QuestionnaireVersion;
+}): { ok: true; data: MapAnswersSuccess } | { ok: false; error: MapAnswersError } {
+  const sessionType = args.sessionType ?? 'profile';
+  const questionnaireVersion = args.questionnaireVersion ?? 'v1';
+  const mapper = QUESTIONNAIRE_MAPPERS[sessionType]?.[questionnaireVersion];
+
+  if (!mapper) {
+    return {
+      ok: false,
+      error: {
+        message: `Unsupported questionnaire mapper for session_type=${sessionType}, questionnaire_version=${questionnaireVersion}`,
+      },
+    };
+  }
+
+  const byId = new Map<string, string>();
+  for (const row of args.answers) {
+    byId.set(row.questionId, row.answer);
+  }
+
+  const mapped = mapper.map(byId);
+  if (!mapped.ok) {
+    return mapped;
+  }
+
+  return {
+    ok: true,
+    data: {
+      surveyResponse: {
+        session_type: sessionType,
+        questionnaire_version: questionnaireVersion,
+        ...mapped.data,
+      },
+      categories: mapped.categories,
+    },
+  };
+}
+
+export function getKnownQuestionIds(sessionType: string, questionnaireVersion: string) {
+  return QUESTIONNAIRE_MAPPERS[sessionType]?.[questionnaireVersion]?.knownQuestionIds ?? new Set<string>();
 }

--- a/src/lib/survey/schemas.ts
+++ b/src/lib/survey/schemas.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 
-/** One answer row; questionId uses DB column names (see mapAnswersToSurveyResponse). */
+import { hasQuestionnaireMapper } from './mapAnswersToSurveyResponse';
+
+/** One answer row; questionId uses mapper IDs. */
 const surveyAnswerRowSchema = z.object({
   questionId: z.string().min(1).max(64),
   answer: z.string().max(8000),
@@ -16,6 +18,8 @@ export const surveyPostBodySchema = z
     lastName: z.string().trim().min(1, 'Last name is required').max(200),
     email: z.union([z.string().email().max(320), z.literal('')]).optional(),
     isAnonymous: z.boolean().optional().default(false),
+    sessionType: z.string().trim().min(1).max(64).optional().default('profile'),
+    questionnaireVersion: z.string().trim().min(1).max(32).optional().default('v1'),
     answers: z.array(surveyAnswerRowSchema).min(1, 'At least one answer is required'),
     /** Cloudflare Turnstile response when captcha enforcement is active. */
     turnstileToken: z.string().min(1).max(8000).optional(),
@@ -28,6 +32,14 @@ export const surveyPostBodySchema = z
         code: z.ZodIssueCode.custom,
         message: 'Email is required unless submitting anonymously',
         path: ['email'],
+      });
+    }
+
+    if (!hasQuestionnaireMapper(data.sessionType, data.questionnaireVersion)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Unsupported questionnaire for sessionType=${data.sessionType} and questionnaireVersion=${data.questionnaireVersion}`,
+        path: ['questionnaireVersion'],
       });
     }
   });

--- a/src/lib/survey/survey.test.ts
+++ b/src/lib/survey/survey.test.ts
@@ -9,6 +9,7 @@ const validAnswers = [
   { questionId: 'peak_performance' as const, answer: 'Introvert, Morning' },
   { questionId: 'motivation' as const, answer: 'growth' },
   { questionId: 'unique_quality' as const, answer: 'Curious collaborator' },
+  { questionId: 'questions' as const, answer: 'How should I prioritize handoffs?' },
 ];
 
 describe('surveyPostBodySchema', () => {
@@ -24,6 +25,8 @@ describe('surveyPostBodySchema', () => {
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect(parsed.data.firstName).toBe('Jane');
+      expect(parsed.data.sessionType).toBe('profile');
+      expect(parsed.data.questionnaireVersion).toBe('v1');
     }
   });
 
@@ -80,14 +83,28 @@ describe('surveyPostBodySchema', () => {
     const parsed = surveyPostBodySchema.safeParse(body);
     expect(parsed.success).toBe(true);
   });
+
+  it('rejects unsupported sessionType/questionnaireVersion pair', () => {
+    const parsed = surveyPostBodySchema.safeParse({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      sessionType: 'profile',
+      questionnaireVersion: 'v999',
+      answers: validAnswers,
+    });
+    expect(parsed.success).toBe(false);
+  });
 });
 
 describe('mapAnswersToSurveyResponsePayload', () => {
   it('maps answers to survey_responses fields (happy path)', () => {
-    const mapped = mapAnswersToSurveyResponsePayload(validAnswers);
+    const mapped = mapAnswersToSurveyResponsePayload({ answers: validAnswers });
     expect(mapped.ok).toBe(true);
     if (mapped.ok) {
-      expect(mapped.data).toEqual({
+      expect(mapped.data.surveyResponse).toEqual({
+        session_type: 'profile',
+        questionnaire_version: 'v1',
         tenure_years: 5,
         learning_style: 'visual',
         shaped_by: 'mentor',
@@ -95,14 +112,22 @@ describe('mapAnswersToSurveyResponsePayload', () => {
         motivation: 'growth',
         unique_quality: 'Curious collaborator',
       });
+      expect(mapped.data.categories).toEqual([
+        {
+          category: 'questions',
+          content: 'How should I prioritize handoffs?',
+        },
+      ]);
     }
   });
 
   it('returns error for unknown questionId', () => {
-    const mapped = mapAnswersToSurveyResponsePayload([
-      { questionId: 'tenure_years', answer: '1' },
-      { questionId: 'not_a_column', answer: 'x' },
-    ]);
+    const mapped = mapAnswersToSurveyResponsePayload({
+      answers: [
+        { questionId: 'tenure_years', answer: '1' },
+        { questionId: 'not_a_column', answer: 'x' },
+      ],
+    });
     expect(mapped.ok).toBe(false);
     if (!mapped.ok) {
       expect(mapped.error.message).toContain('Unknown questionId');
@@ -110,13 +135,15 @@ describe('mapAnswersToSurveyResponsePayload', () => {
   });
 
   it('last duplicate questionId wins', () => {
-    const mapped = mapAnswersToSurveyResponsePayload([
-      { questionId: 'tenure_years', answer: '1' },
-      { questionId: 'tenure_years', answer: '7' },
-    ]);
+    const mapped = mapAnswersToSurveyResponsePayload({
+      answers: [
+        { questionId: 'tenure_years', answer: '1' },
+        { questionId: 'tenure_years', answer: '7' },
+      ],
+    });
     expect(mapped.ok).toBe(true);
     if (mapped.ok) {
-      expect(mapped.data.tenure_years).toBe(7);
+      expect(mapped.data.surveyResponse.tenure_years).toBe(7);
     }
   });
 });

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -11,6 +11,16 @@ export type PeakPerformanceType =
   | 'Ambivert, Night';
 export type MotivationType = 'impact' | 'growth' | 'recognition' | 'autonomy' | 'purpose';
 export type ModerationStatus = 'pending' | 'approved' | 'rejected';
+export type SurveySessionType = string;
+export type QuestionnaireVersion = string;
+export type IntentCategory =
+  | 'questions'
+  | 'concerns'
+  | 'needs'
+  | 'accomplishments'
+  | 'stats'
+  | 'constraints'
+  | 'signals';
 export type AlignmentContextSource = 'ui' | 'import' | 'api';
 export type AlignmentContextStatus = 'draft' | 'active' | 'archived';
 
@@ -27,6 +37,8 @@ export type AttendeeRow = {
 export type SurveyResponseRow = {
   id: string;
   attendee_id: string;
+  session_type: SurveySessionType;
+  questionnaire_version: QuestionnaireVersion;
   tenure_years: number | null;
   learning_style: LearningStyle | null;
   shaped_by: ShapedBy | null;
@@ -36,6 +48,16 @@ export type SurveyResponseRow = {
   status: ModerationStatus;
   moderated_at: string | null;
   test_data: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+
+export type SurveyResponseIntentCategoryRow = {
+  id: string;
+  response_id: string;
+  category: IntentCategory;
+  content: string;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
### Motivation

- Allow Sync Session intake to evolve question sets and capture intent buckets without breaking existing stored submissions by versioning questionnaires and normalizing intent categories.

### Description

- Persist `session_type` and `questionnaire_version` on `survey_responses` with defaults to preserve legacy behavior and add a new normalized `survey_response_intent_categories` table covering `questions`, `concerns`, `needs`, `accomplishments`, `stats`, `constraints`, and `signals` (schema changes in `src/db/schema.ts` and bootstrap/migration logic in `src/db/client.ts`).
- Refactor the answer mapper into a versioned registry keyed by `(session_type, questionnaire_version)` and implemented `profile/v1` mapper that emits both column fields and intent category payloads (`src/lib/survey/mapAnswersToSurveyResponse.ts`).
- Update request validation to accept `sessionType` and `questionnaireVersion`, default to `profile`/`v1`, and reject unsupported mapper pairs at parse time (`src/lib/survey/schemas.ts`).
- Wire the API and repository flow so POST `/api/survey` passes version metadata into the mapper and the repository persists the versioned metadata and normalized categories while keeping backward compatibility for older submissions (`src/app/api/survey/route.ts`, `src/lib/storage/repositories/survey.ts`, `src/lib/hooks/useSyncSessionForm.ts`).

### Testing

- Ran type checking with `npm run type-check`, which completed successfully.
- Ran unit tests for the survey mapping with `npm run test -- src/lib/survey/survey.test.ts`, all tests passed.
- Ran linter with `npm run lint`, which completed (repository retains unrelated existing ESLint warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabb5abfb4832cae2df9452946ded5)