### PR TITLE
feat: intent ledger read model + API + admin intent-gaps UI

### DIFF
--- a/docs/agent/INTEGRATION_PATHS.md
+++ b/docs/agent/INTEGRATION_PATHS.md
@@ -11,6 +11,7 @@
 ## Primary: HTTP + thin CLI
 
 - **Alignment context:** Full list/create/patch/delete via [ALIGNMENT_CONTEXT_API.md](./ALIGNMENT_CONTEXT_API.md) and [`scripts/alignment-context-cli.mjs`](../../scripts/alignment-context-cli.mjs) (`list`, `create`, `patch`, `delete`).
+- **Intent ledger read model:** `GET /api/intent-ledger` and `GET /api/intent-ledger/:attendeeId` for merged Sync Session + clarification + alignment records (see [INTENT_LEDGER_API.md](./INTENT_LEDGER_API.md)).
 - **Brain-map graph:** `GET /api/brain-map/graph` for the JSON document consumed by the viewer.
 
 Set `OPENGRIMOIRE_BASE_URL` (or legacy `OPENGRIMOIRE_BASE_URL`) to your app origin (local dev defaults to port **3001** — see README). Set `ALIGNMENT_CONTEXT_API_SECRET` when the server enforces `x-alignment-context-key`.

--- a/docs/agent/INTENT_LEDGER_API.md
+++ b/docs/agent/INTENT_LEDGER_API.md
@@ -1,0 +1,63 @@
+# Intent ledger API (operator/harness alignment loop)
+
+This read model merges three planes into one per-attendee record:
+
+1. **Fixed Sync Session data** (`attendees` + `survey_responses`).
+2. **Clarification queue outcomes** (`clarification_requests`).
+3. **Alignment context state** (`alignment_context_items`).
+
+Use this when a harness needs one place to answer: **"what intent gaps are unresolved, what was resolved, and should we escalate?"**
+
+---
+
+## Endpoints
+
+### `GET /api/intent-ledger`
+
+Returns all attendee records in one payload.
+
+**Auth:** same pattern as study APIs — either:
+- operator admin session cookie, or
+- `x-alignment-context-key` (when `ALIGNMENT_CONTEXT_API_SECRET` is configured).
+
+### `GET /api/intent-ledger/:attendeeId`
+
+Returns one attendee record.
+
+- `400` for invalid UUID
+- `404` when attendee is not found
+
+---
+
+## Canonical intent event shape
+
+Every merged record includes `intent_events[]` with the canonical shape:
+
+- `type` — `sync_session_profile | clarification_request | clarification_resolution | alignment_context`
+- `category` — `profile | intent_gap | intent_resolution | alignment_context`
+- `status` — normalized lifecycle (`pending`, `resolved`, `active`, `archived`, `info`)
+- `source` — `sync_session | clarification_queue | alignment_context`
+- `confidence` — numeric confidence for inferred linkage / interpretation
+- `timestamp` — event ordering key
+
+Additional fields (`title`, `detail`, `reference_id`, `attendee_id`, `session_id`) keep events traceable.
+
+---
+
+## Harness write/read loop
+
+### Write side
+
+1. Create fixed profile baseline via `POST /api/survey` (Sync Session).
+2. Publish gaps/questions via `POST /api/clarification-requests`.
+3. Resolve gap via `PATCH /api/clarification-requests/:id` (`answered` / `superseded`).
+4. Promote durable outcomes via `POST`/`PATCH /api/alignment-context`.
+
+### Read side
+
+1. Poll `GET /api/intent-ledger` (or per attendee endpoint).
+2. Route records where `intent_gaps.unresolved > 0` into operator inbox/escalation.
+3. Consume `intent_gaps.escalation_prompts[]` as suggested handoff prompts.
+4. Keep your own harness checkpoints idempotent by storing seen `intent_events[].id`.
+
+This keeps the app-side domain model thin while giving harnesses a single alignment-oriented read model.

--- a/src/app/admin/alignment/page.tsx
+++ b/src/app/admin/alignment/page.tsx
@@ -21,6 +21,15 @@ type AlignmentItem = {
   updated_at: string;
 };
 
+type IntentLedgerRecord = {
+  attendee: { id: string; first_name: string; last_name: string | null };
+  intent_gaps: {
+    unresolved: number;
+    resolved: number;
+    escalation_prompts: string[];
+  };
+};
+
 export default function AdminAlignmentPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -72,6 +81,24 @@ export default function AdminAlignmentPage() {
   });
 
   const items = alignmentQuery.data ?? [];
+  const intentLedgerQuery = useQuery({
+    queryKey: ['admin', 'intent-ledger'],
+    enabled: !!user,
+    queryFn: async () => {
+      const res = await fetch('/api/intent-ledger', {
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to load intent ledger (${res.status})`);
+      }
+      const data = (await res.json()) as { items?: IntentLedgerRecord[] };
+      return data.items ?? [];
+    },
+  });
+  const intentRows = intentLedgerQuery.data ?? [];
+  const unresolvedCount = intentRows.reduce((sum, row) => sum + row.intent_gaps.unresolved, 0);
+  const resolvedCount = intentRows.reduce((sum, row) => sum + row.intent_gaps.resolved, 0);
+  const escalationRows = intentRows.filter((row) => row.intent_gaps.escalation_prompts.length > 0);
 
   useEffect(() => {
     if (!user) return;
@@ -222,6 +249,43 @@ export default function AdminAlignmentPage() {
             {loadError ?? queryError}
           </div>
         )}
+
+        <section className="mb-10 rounded-lg border border-amber-200 bg-amber-50 p-6 shadow-sm" aria-labelledby="intent-gaps-heading">
+          <h2 id="intent-gaps-heading" className="text-lg font-semibold text-amber-900">
+            Intent gaps ledger
+          </h2>
+          <p className="mt-1 text-sm text-amber-800">
+            Merged Sync Session + clarification + alignment read model for operator/harness handoff.
+          </p>
+          {intentLedgerQuery.isPending ? (
+            <p className="mt-3 text-sm text-amber-700">Loading intent ledger…</p>
+          ) : (
+            <div className="mt-4 space-y-3 text-sm">
+              <p className="text-amber-900">
+                Unresolved gaps: <strong>{unresolvedCount}</strong> · Resolved outcomes:{' '}
+                <strong>{resolvedCount}</strong>
+              </p>
+              {escalationRows.length === 0 ? (
+                <p className="text-amber-800">No escalation prompts right now.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {escalationRows.map((row) => (
+                    <li key={row.attendee.id} className="rounded border border-amber-300 bg-white p-3">
+                      <div className="font-medium text-gray-900">
+                        {row.attendee.first_name} {row.attendee.last_name ?? ''} ({row.attendee.id})
+                      </div>
+                      <ul className="mt-1 list-disc pl-5 text-gray-700">
+                        {row.intent_gaps.escalation_prompts.map((prompt) => (
+                          <li key={prompt}>{prompt}</li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </section>
 
         <section className="mb-10 rounded-lg border border-gray-200 bg-white p-6 shadow-sm" aria-labelledby="create-heading">
           <h2 id="create-heading" className="mb-4 text-lg font-semibold text-gray-900">

--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -79,6 +79,16 @@ const CAPABILITIES = {
       auth: 'OpenGrimoire operator session cookie',
     },
     {
+      path: '/api/intent-ledger',
+      methods: ['GET'],
+      auth: 'OpenGrimoire operator session cookie or x-alignment-context-key (same gate as alignment API)',
+    },
+    {
+      path: '/api/intent-ledger/:attendeeId',
+      methods: ['GET'],
+      auth: 'OpenGrimoire operator session cookie or x-alignment-context-key (same gate as alignment API)',
+    },
+    {
       path: '/api/admin/moderation-queue',
       methods: ['GET'],
       auth: 'OpenGrimoire operator session cookie',

--- a/src/app/api/intent-ledger/[attendeeId]/route.ts
+++ b/src/app/api/intent-ledger/[attendeeId]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { checkAlignmentOrAdminSession } from '@/lib/alignment-context/api-auth';
+import { getIntentLedgerByAttendee } from '@/lib/storage/repositories/intent-ledger';
+
+type RouteContext = { params: { attendeeId: string } };
+
+export async function GET(request: Request, context: RouteContext) {
+  const gate = await checkAlignmentOrAdminSession(request);
+  if (!gate.ok) {
+    return gate.response;
+  }
+
+  const { attendeeId } = context.params;
+  if (!attendeeId || !/^[0-9a-f-]{36}$/i.test(attendeeId)) {
+    return NextResponse.json({ error: 'Invalid attendeeId' }, { status: 400 });
+  }
+
+  const { data, error } = getIntentLedgerByAttendee(attendeeId);
+  if (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[intent-ledger/:attendeeId] get failed:', error.code, error.message);
+    } else {
+      console.error('[intent-ledger/:attendeeId] get failed:', error.code);
+    }
+    return NextResponse.json({ error: 'Failed to load intent ledger record' }, { status: 500 });
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ item: data }, { headers: { 'Cache-Control': 'private, no-store' } });
+}

--- a/src/app/api/intent-ledger/route.ts
+++ b/src/app/api/intent-ledger/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { checkAlignmentOrAdminSession } from '@/lib/alignment-context/api-auth';
+import { listIntentLedger } from '@/lib/storage/repositories/intent-ledger';
+
+export async function GET(request: Request) {
+  const gate = await checkAlignmentOrAdminSession(request);
+  if (!gate.ok) {
+    return gate.response;
+  }
+
+  const { data, error } = listIntentLedger();
+  if (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[intent-ledger] list failed:', error.code, error.message);
+    } else {
+      console.error('[intent-ledger] list failed:', error.code);
+    }
+    return NextResponse.json({ error: 'Failed to load intent ledger' }, { status: 500 });
+  }
+
+  return NextResponse.json({ items: data ?? [] }, { headers: { 'Cache-Control': 'private, no-store' } });
+}

--- a/src/lib/intent-ledger/types.ts
+++ b/src/lib/intent-ledger/types.ts
@@ -1,0 +1,72 @@
+export type IntentEventType =
+  | 'sync_session_profile'
+  | 'clarification_request'
+  | 'clarification_resolution'
+  | 'alignment_context';
+
+export type IntentEventCategory =
+  | 'profile'
+  | 'intent_gap'
+  | 'intent_resolution'
+  | 'alignment_context';
+
+export type IntentEventStatus = 'pending' | 'resolved' | 'active' | 'archived' | 'info';
+
+export type IntentEventSource = 'sync_session' | 'clarification_queue' | 'alignment_context';
+
+export type IntentEvent = {
+  id: string;
+  attendee_id: string | null;
+  session_id: string | null;
+  type: IntentEventType;
+  category: IntentEventCategory;
+  status: IntentEventStatus;
+  source: IntentEventSource;
+  confidence: number;
+  timestamp: string;
+  title: string;
+  detail: string | null;
+  reference_id: string;
+};
+
+export type IntentGapSummary = {
+  unresolved: number;
+  resolved: number;
+  escalation_prompts: string[];
+};
+
+export type IntentLedgerRecord = {
+  attendee: {
+    id: string;
+    first_name: string;
+    last_name: string | null;
+    is_anonymous: boolean;
+    created_at: string;
+  };
+  sync_sessions: Array<{
+    survey_response_id: string;
+    created_at: string;
+    status: string;
+    learning_style: string | null;
+    motivation: string | null;
+    peak_performance: string | null;
+    unique_quality: string | null;
+  }>;
+  alignment_items: Array<{
+    id: string;
+    title: string;
+    status: string;
+    linked_node_id: string | null;
+    updated_at: string;
+  }>;
+  clarification_requests: Array<{
+    id: string;
+    status: string;
+    prompt: string;
+    linked_node_id: string | null;
+    created_at: string;
+    resolved_at: string | null;
+  }>;
+  intent_events: IntentEvent[];
+  intent_gaps: IntentGapSummary;
+};

--- a/src/lib/storage/repositories/intent-ledger.ts
+++ b/src/lib/storage/repositories/intent-ledger.ts
@@ -1,0 +1,242 @@
+import { getSqlite } from '@/db/client';
+import { listAlignmentContextItems } from '@/lib/storage/repositories/alignment';
+import { listClarificationRequests, type ClarificationRequestRow } from '@/lib/storage/repositories/clarification';
+import type { IntentEvent, IntentEventStatus, IntentLedgerRecord } from '@/lib/intent-ledger/types';
+
+type AttendeeBase = IntentLedgerRecord['attendee'];
+
+type SyncSessionRow = IntentLedgerRecord['sync_sessions'][number];
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+
+function normalizeStatus(status: string): IntentEventStatus {
+  if (status === 'pending') return 'pending';
+  if (status === 'answered') return 'resolved';
+  if (status === 'active') return 'active';
+  if (status === 'archived' || status === 'superseded') return 'archived';
+  return 'info';
+}
+
+function maybeString(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() ? v : null;
+}
+
+function extractRefsFromMetadata(meta: Record<string, unknown>): { attendeeId?: string; sessionId?: string } {
+  const attendeeId = maybeString(meta.attendeeId) ?? maybeString(meta.attendee_id) ?? undefined;
+  const sessionId =
+    maybeString(meta.surveyResponseId) ??
+    maybeString(meta.survey_response_id) ??
+    maybeString(meta.syncSessionId) ??
+    maybeString(meta.session_id) ??
+    undefined;
+
+  if (attendeeId || sessionId) return { attendeeId, sessionId };
+
+  const rawRef =
+    maybeString(meta.opengrimoireRef) ??
+    maybeString(meta.reference) ??
+    maybeString(meta.contextRef) ??
+    '';
+  if (!rawRef) return {};
+
+  const matches = rawRef.match(UUID_RE) ?? [];
+  if (matches.length === 0) return {};
+  return {
+    attendeeId: matches[0],
+    sessionId: matches[1],
+  };
+}
+
+export function listIntentLedger(): { data: IntentLedgerRecord[] | null; error: { code: string; message: string } | null } {
+  const sqlite = getSqlite();
+  try {
+    const attendees = sqlite
+      .prepare(
+        `SELECT id, first_name, last_name, is_anonymous, created_at
+         FROM attendees
+         ORDER BY created_at DESC`
+      )
+      .all() as Array<Record<string, unknown>>;
+
+    const sessions = sqlite
+      .prepare(
+        `SELECT id, attendee_id, created_at, status, learning_style, motivation, peak_performance, unique_quality
+         FROM survey_responses
+         ORDER BY created_at DESC`
+      )
+      .all() as Array<Record<string, unknown>>;
+
+    const base = new Map<string, IntentLedgerRecord>();
+    const sessionToAttendee = new Map<string, string>();
+
+    for (const row of attendees) {
+      const attendee: AttendeeBase = {
+        id: String(row.id),
+        first_name: String(row.first_name),
+        last_name: row.last_name == null ? null : String(row.last_name),
+        is_anonymous: Boolean(row.is_anonymous),
+        created_at: String(row.created_at),
+      };
+      base.set(attendee.id, {
+        attendee,
+        sync_sessions: [],
+        alignment_items: [],
+        clarification_requests: [],
+        intent_events: [],
+        intent_gaps: { unresolved: 0, resolved: 0, escalation_prompts: [] },
+      });
+    }
+
+    for (const row of sessions) {
+      const attendeeId = String(row.attendee_id);
+      sessionToAttendee.set(String(row.id), attendeeId);
+      const record = base.get(attendeeId);
+      if (!record) continue;
+
+      const session: SyncSessionRow = {
+        survey_response_id: String(row.id),
+        created_at: String(row.created_at),
+        status: String(row.status),
+        learning_style: row.learning_style == null ? null : String(row.learning_style),
+        motivation: row.motivation == null ? null : String(row.motivation),
+        peak_performance: row.peak_performance == null ? null : String(row.peak_performance),
+        unique_quality: row.unique_quality == null ? null : String(row.unique_quality),
+      };
+      record.sync_sessions.push(session);
+      record.intent_events.push({
+        id: `event-session-${session.survey_response_id}`,
+        attendee_id: attendeeId,
+        session_id: session.survey_response_id,
+        type: 'sync_session_profile',
+        category: 'profile',
+        status: normalizeStatus(session.status),
+        source: 'sync_session',
+        confidence: 1,
+        timestamp: session.created_at,
+        title: 'Sync Session profile submitted',
+        detail: session.unique_quality,
+        reference_id: session.survey_response_id,
+      });
+    }
+
+    const alignment = listAlignmentContextItems({ statusFilter: null, limit: 500 }).data ?? [];
+    const clarification = listClarificationRequests({ statusFilter: null, limit: 500 }).data ?? [];
+
+    const linkedNodeToAttendee = new Map<string, string>();
+    for (const row of alignment) {
+      if (!row.attendee_id) continue;
+      const record = base.get(row.attendee_id);
+      if (!record) continue;
+      record.alignment_items.push({
+        id: row.id,
+        title: row.title,
+        status: row.status,
+        linked_node_id: row.linked_node_id,
+        updated_at: row.updated_at,
+      });
+      if (row.linked_node_id) linkedNodeToAttendee.set(row.linked_node_id, row.attendee_id);
+      record.intent_events.push({
+        id: `event-alignment-${row.id}`,
+        attendee_id: row.attendee_id,
+        session_id: null,
+        type: 'alignment_context',
+        category: 'alignment_context',
+        status: normalizeStatus(row.status),
+        source: 'alignment_context',
+        confidence: 0.95,
+        timestamp: row.updated_at,
+        title: row.title,
+        detail: row.body,
+        reference_id: row.id,
+      });
+    }
+
+    for (const row of clarification) {
+      const inferred = inferAttendeeForClarification(row, sessionToAttendee, linkedNodeToAttendee);
+      if (!inferred.attendeeId) continue;
+      const record = base.get(inferred.attendeeId);
+      if (!record) continue;
+
+      record.clarification_requests.push({
+        id: row.id,
+        status: row.status,
+        prompt: row.question_spec.prompt,
+        linked_node_id: row.linked_node_id,
+        created_at: row.created_at,
+        resolved_at: row.resolved_at,
+      });
+
+      record.intent_events.push({
+        id: `event-clarification-${row.id}`,
+        attendee_id: inferred.attendeeId,
+        session_id: inferred.sessionId,
+        type: row.status === 'pending' ? 'clarification_request' : 'clarification_resolution',
+        category: row.status === 'pending' ? 'intent_gap' : 'intent_resolution',
+        status: normalizeStatus(row.status),
+        source: 'clarification_queue',
+        confidence: row.status === 'pending' ? 0.8 : 0.95,
+        timestamp: row.resolved_at ?? row.created_at,
+        title: row.question_spec.prompt,
+        detail: row.agent_metadata.reason ?? null,
+        reference_id: row.id,
+      });
+    }
+
+    const records = Array.from(base.values());
+    for (const record of records) {
+      record.intent_events.sort((a: IntentEvent, b: IntentEvent) => b.timestamp.localeCompare(a.timestamp));
+      const unresolved = record.intent_events.filter(
+        (e: IntentEvent) => e.category === 'intent_gap' && e.status === 'pending'
+      ).length;
+      const resolved = record.intent_events.filter(
+        (e: IntentEvent) => e.category === 'intent_resolution' || e.status === 'resolved'
+      ).length;
+      const prompts: string[] = [];
+      if (unresolved > 0) {
+        prompts.push(`Resolve ${unresolved} pending clarification request(s) for this attendee.`);
+      }
+      const hasActiveAlignment = record.alignment_items.some((i) => i.status === 'active');
+      if (!hasActiveAlignment && unresolved > 0) {
+        prompts.push('No active alignment context item linked yet; escalate to operator handoff.');
+      }
+      record.intent_gaps = { unresolved, resolved, escalation_prompts: prompts };
+    }
+
+    return { data: records, error: null };
+  } catch (e) {
+    const err = e instanceof Error ? e : new Error(String(e));
+    return { data: null, error: { code: 'SQLITE_ERROR', message: err.message } };
+  }
+}
+
+export function getIntentLedgerByAttendee(attendeeId: string): {
+  data: IntentLedgerRecord | null;
+  error: { code: string; message: string } | null;
+} {
+  const listed = listIntentLedger();
+  if (listed.error) return { data: null, error: listed.error };
+  const found = (listed.data ?? []).find((r) => r.attendee.id === attendeeId) ?? null;
+  return { data: found, error: null };
+}
+
+function inferAttendeeForClarification(
+  row: ClarificationRequestRow,
+  sessionToAttendee: Map<string, string>,
+  linkedNodeToAttendee: Map<string, string>
+): { attendeeId: string | null; sessionId: string | null } {
+  const refs = extractRefsFromMetadata(row.agent_metadata as Record<string, unknown>);
+  const sessionId = refs.sessionId ?? null;
+  if (refs.attendeeId) {
+    return { attendeeId: refs.attendeeId, sessionId };
+  }
+
+  if (sessionId && sessionToAttendee.has(sessionId)) {
+    return { attendeeId: sessionToAttendee.get(sessionId) ?? null, sessionId };
+  }
+
+  if (row.linked_node_id && linkedNodeToAttendee.has(row.linked_node_id)) {
+    return { attendeeId: linkedNodeToAttendee.get(row.linked_node_id) ?? null, sessionId };
+  }
+
+  return { attendeeId: null, sessionId };
+}


### PR DESCRIPTION
### Motivation

- Provide a single attendee-centric read model that merges fixed Sync Session profiles, clarification queue outcomes, and alignment-context items to make harness/operator decisions easier.
- Surface unresolved vs resolved intent gaps and suggested escalations so operators/harnesses can route outstanding questions and promote durable outcomes.

### Description

- Added a repository-level aggregator `src/lib/storage/repositories/intent-ledger.ts` that joins `attendees`/`survey_responses`, `clarification_requests`, and `alignment_context_items` into `IntentLedgerRecord` per-attendee records and computes `intent_gaps` and `intent_events`.
- Introduced canonical types at `src/lib/intent-ledger/types.ts` including the `IntentEvent` shape with `type`, `category`, `status`, `source`, `confidence`, `timestamp`, and trace fields.
- Implemented new API endpoints `GET /api/intent-ledger` and `GET /api/intent-ledger/:attendeeId` under `src/app/api/intent-ledger/*` using the existing `checkAlignmentOrAdminSession` auth gate and returning private/no-store JSON.
- Updated admin UX at `src/app/admin/alignment/page.tsx` to fetch the ledger and display unresolved vs resolved counts and per-attendee `escalation_prompts`.
- Documented the read model and the harness write/read loop in `docs/agent/INTENT_LEDGER_API.md` and linked it from `docs/agent/INTEGRATION_PATHS.md`, and added the routes to the `CAPABILITIES` manifest at `src/app/api/capabilities/route.ts`.

### Testing

- Ran `npm run type-check` (`tsc --noEmit`) which completed successfully. 
- Ran `npm run lint` which completed successfully (repository has pre-existing ESLint warnings unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabb60e6cc832c90a76406ac8c412d)