### PR TITLE
Add affect overlays and intent drilldown to context atlas

### DIFF
--- a/docs/BRAIN_MAP_SCHEMA.md
+++ b/docs/BRAIN_MAP_SCHEMA.md
@@ -29,6 +29,8 @@ This document describes the payload returned by `GET /api/brain-map/graph`. The 
 | `compass_axis` | string | no | Optional orientation axis label from OpenCompass-style context models |
 | `grimoire_tags` | string[] | no | Optional OpenGrimoire tags for operator wisdom grouping |
 | `insight_level` | string | no | Optional qualitative insight level (`raw`, `curated`, `validated`) |
+| `affect_overlay` | object | no | Optional affect signals for intent-aware overlays: `concern_level` (0..1), `need_urgency` (0..1), `accomplishment_momentum` (0..1), `unresolved_question_count` (integer), `confidence_drift` (-1..1; UI generally renders magnitude). |
+| `intent_artifacts` | object | no | Optional links to intent context sources: `survey_refs`, `clarification_refs`, `alignment_context_refs`, `session_refs` (all string arrays). |
 
 The builder emits `id`, `group`, `accessCount`, `path`, **`layer`**, **`provenance`**, and vault-specific `id`/`path` prefixes (`vault/<label>/...`). Optional fields such as `constraint` / `risk_tier` are for forward-compatible enrichments.
 
@@ -50,6 +52,8 @@ The builder emits `id`, `group`, `accessCount`, `path`, **`layer`**, **`provenan
 | `compass_axis` | string | no | Optional orientation axis label |
 | `grimoire_tags` | string[] | no | Optional OpenGrimoire tags |
 | `insight_level` | string | no | Optional insight level marker |
+| `affect_by_session` | object | no | Optional per-session overlay map. Keys are session ids; values follow `affect_overlay` shape from nodes. |
+| `intent_artifacts_by_session` | object | no | Optional per-session intent refs map. Keys are session ids; values follow `intent_artifacts` shape from nodes. |
 
 ## API behavior
 
@@ -64,6 +68,8 @@ The builder emits `id`, `group`, `accessCount`, `path`, **`layer`**, **`provenan
 
 - Consumers must ignore unknown fields.
 - New optional fields must not be required by the UI; the OpenGrimoire viewer tolerates their absence.
+- Affect overlay fields are **optional** and default-safe: if omitted, the graph renders with existing topology styling and no affect columns/filters.
+- Session-level affect/intent maps are optional enrichments for drilldowns; legacy edge payloads without these maps remain valid.
 
 ## State ingest (builder)
 

--- a/e2e/context-atlas.spec.ts
+++ b/e2e/context-atlas.spec.ts
@@ -38,16 +38,42 @@ test.describe('Context Atlas (Brain Map)', () => {
 
     await page.getByRole('tab', { name: 'Table' }).click();
     await expect(page.getByRole('cell', { name: '.cursor/state/handoff_fixture.md' })).toBeVisible();
+    await expect(page.getByRole('cell', { name: '.cursor/state/plain_fixture.md' })).toBeVisible();
     await expect(page.getByTestId('col-trust-score')).toBeVisible();
     await expect(page.getByRole('columnheader', { name: 'Trust score' })).toBeVisible();
     await expect(page.getByRole('cell', { name: '0.85' })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: 'Grimoire tags' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'fixture, opengrimoire' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Concern' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Urgency' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Unresolved questions' })).toBeVisible();
 
     await page.getByRole('tab', { name: 'Vault' }).click();
     await expect(
       page.getByText(/No nodes in this layer for the current filter/)
     ).toBeVisible();
+  });
+
+  test('overlay filter + intent drilldown are shown for affect-enabled nodes', async ({ page }) => {
+    const body = loadBrainMapFixture('brain-map-state-only.json');
+    await page.route('**/api/brain-map/graph**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body,
+      });
+    });
+    await page.goto('/context-atlas');
+    await expect(page.getByText('Loading brain map')).not.toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('tab', { name: 'Table' }).click();
+    await page.getByRole('row', { name: /handoff_fixture/ }).click();
+    await expect(page.getByTestId('intent-drilldown-panel')).toBeVisible();
+    await expect(page.getByTestId('intent-survey-refs')).toContainText('survey:fixture-2026-03-19');
+
+    await page.getByTestId('affect-filter-checkbox').check();
+    await expect(page.getByRole('cell', { name: '.cursor/state/plain_fixture.md' })).toHaveCount(0);
+    await expect(page.getByRole('cell', { name: '.cursor/state/handoff_fixture.md' })).toBeVisible();
   });
 
   test('mocked empty API with sessionCount 0: placeholder hint is visible', async ({ page }) => {

--- a/e2e/fixtures/brain-map-state-only.json
+++ b/e2e/fixtures/brain-map-state-only.json
@@ -9,10 +9,54 @@
       "trust_score": 0.85,
       "compass_axis": "alignment",
       "grimoire_tags": ["fixture", "opengrimoire"],
-      "insight_level": "curated"
+      "insight_level": "curated",
+      "affect_overlay": {
+        "concern_level": 0.7,
+        "need_urgency": 0.8,
+        "accomplishment_momentum": 0.55,
+        "unresolved_question_count": 2,
+        "confidence_drift": -0.2
+      },
+      "intent_artifacts": {
+        "survey_refs": ["survey:fixture-2026-03-19"],
+        "clarification_refs": ["clarification:fixture-q1"],
+        "alignment_context_refs": ["alignment:fixture-a1"],
+        "session_refs": ["openharness:fixture-session"]
+      }
+    },
+    {
+      "id": "fixture-state-node-no-affect",
+      "group": "tools",
+      "accessCount": 1,
+      "path": ".cursor/state/plain_fixture.md",
+      "layer": "state"
     }
   ],
-  "edges": [],
+  "edges": [
+    {
+      "source": "fixture-state-node",
+      "target": "fixture-state-node-no-affect",
+      "weight": 1,
+      "sessionType": "general",
+      "sessions": ["openharness:fixture-session"],
+      "affect_by_session": {
+        "openharness:fixture-session": {
+          "concern_level": 0.6,
+          "need_urgency": 0.7,
+          "accomplishment_momentum": 0.4,
+          "unresolved_question_count": 1,
+          "confidence_drift": 0.1
+        }
+      },
+      "intent_artifacts_by_session": {
+        "openharness:fixture-session": {
+          "survey_refs": ["survey:fixture-2026-03-19"],
+          "clarification_refs": ["clarification:fixture-q1"],
+          "alignment_context_refs": ["alignment:fixture-a1"]
+        }
+      }
+    }
+  ],
   "generated": "2026-03-19T00:00:00.000Z",
   "sessionCount": 1
 }

--- a/src/components/BrainMap/BrainMapGraph.tsx
+++ b/src/components/BrainMap/BrainMapGraph.tsx
@@ -45,6 +45,8 @@ export interface BrainMapNode {
   compass_axis?: string;
   grimoire_tags?: string[];
   insight_level?: string;
+  affect_overlay?: BrainMapAffectOverlay;
+  intent_artifacts?: BrainMapIntentArtifacts;
 }
 
 export interface BrainMapEdge {
@@ -58,6 +60,8 @@ export interface BrainMapEdge {
   provenance?: BrainMapNodeSource;
   risk_tier?: BrainMapRiskTier;
   review_status?: BrainMapReviewStatus;
+  affect_by_session?: Record<string, BrainMapAffectOverlay>;
+  intent_artifacts_by_session?: Record<string, BrainMapIntentArtifacts>;
 }
 
 export interface BrainMapSourceRoot {
@@ -76,6 +80,28 @@ export interface BrainMapData {
 
 type GraphNode = BrainMapNode & d3Force.SimulationNodeDatum;
 type GraphLink = Omit<BrainMapEdge, 'source' | 'target'> & d3Force.SimulationLinkDatum<GraphNode>;
+type AffectMetricKey =
+  | 'concern_level'
+  | 'need_urgency'
+  | 'accomplishment_momentum'
+  | 'unresolved_question_count'
+  | 'confidence_drift';
+type AffectOverlayMode = 'off' | AffectMetricKey;
+
+export interface BrainMapAffectOverlay {
+  concern_level?: number;
+  need_urgency?: number;
+  accomplishment_momentum?: number;
+  unresolved_question_count?: number;
+  confidence_drift?: number;
+}
+
+export interface BrainMapIntentArtifacts {
+  survey_refs?: string[];
+  clarification_refs?: string[];
+  alignment_context_refs?: string[];
+  session_refs?: string[];
+}
 
 const EMPTY_GRAPH: BrainMapData = {
   nodes: [
@@ -144,6 +170,44 @@ function formatGrimoireTags(tags: string[] | undefined): string {
   return tags.join(', ');
 }
 
+function normalizeMetricValue(
+  metric: AffectMetricKey,
+  value: number | undefined,
+  maxUnresolvedQuestions: number
+): number | null {
+  if (typeof value !== 'number') return null;
+  if (metric === 'confidence_drift') return Math.max(0, Math.min(1, Math.abs(value)));
+  if (metric === 'unresolved_question_count') {
+    const bound = Math.max(1, maxUnresolvedQuestions);
+    return Math.max(0, Math.min(1, value / bound));
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function metricLabel(metric: AffectMetricKey): string {
+  return metric.replaceAll('_', ' ');
+}
+
+function hasAffectSignals(node: BrainMapNode): boolean {
+  const aff = node.affect_overlay;
+  if (!aff) return false;
+  return (
+    typeof aff.concern_level === 'number' ||
+    typeof aff.need_urgency === 'number' ||
+    typeof aff.accomplishment_momentum === 'number' ||
+    typeof aff.unresolved_question_count === 'number' ||
+    typeof aff.confidence_drift === 'number'
+  );
+}
+
+function hasIntentArtifacts(node: BrainMapNode): boolean {
+  const refs = node.intent_artifacts;
+  if (!refs) return false;
+  return Boolean(
+    refs.survey_refs?.length || refs.clarification_refs?.length || refs.alignment_context_refs?.length || refs.session_refs?.length
+  );
+}
+
 function filterGraphByLayer(data: BrainMapData, layer: LayerFilter): BrainMapData {
   if (layer === 'all') return data;
   const ids = new Set(data.nodes.filter((n) => nodeLayer(n) === layer).map((n) => n.id));
@@ -164,6 +228,9 @@ export default function BrainMapGraph() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [affectOverlayMode, setAffectOverlayMode] = useState<AffectOverlayMode>('off');
+  const [affectFilterOnly, setAffectFilterOnly] = useState(false);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   /** True when API returned 200 but no nodes (empty build); UI shows placeholder graph — use All/State layer, or rebuild JSON. */
   const [placeholderFromEmptyApi, setPlaceholderFromEmptyApi] = useState(false);
 
@@ -208,8 +275,24 @@ export default function BrainMapGraph() {
 
   const filteredData = useMemo(() => {
     if (!data) return null;
-    return filterGraphByLayer(data, layerFilter);
-  }, [data, layerFilter]);
+    const byLayer = filterGraphByLayer(data, layerFilter);
+    if (!affectFilterOnly) return byLayer;
+    const ids = new Set(byLayer.nodes.filter(hasAffectSignals).map((n) => n.id));
+    return {
+      ...byLayer,
+      nodes: byLayer.nodes.filter((n) => ids.has(n.id)),
+      edges: byLayer.edges.filter((e) => ids.has(e.source) && ids.has(e.target)),
+    };
+  }, [data, layerFilter, affectFilterOnly]);
+
+  const maxUnresolvedQuestions = useMemo(
+    () =>
+      Math.max(
+        1,
+        ...(filteredData?.nodes.map((n) => n.affect_overlay?.unresolved_question_count ?? 0) ?? [1])
+      ),
+    [filteredData]
+  );
 
   const renderGraph = useCallback(() => {
     if (!svgRef.current || !filteredData) return;
@@ -259,8 +342,27 @@ export default function BrainMapGraph() {
       .selectAll<SVGCircleElement, GraphNode>('circle')
       .data(nodes)
       .join('circle')
-      .attr('r', (d) => 4 + Math.min(d.accessCount, 8))
-      .attr('fill', (d) => GROUP_COLORS[d.group] ?? '#6b7280')
+      .attr('r', (d) => {
+        const base = 4 + Math.min(d.accessCount, 8);
+        if (affectOverlayMode === 'off') return base;
+        const norm = normalizeMetricValue(
+          affectOverlayMode,
+          d.affect_overlay?.[affectOverlayMode],
+          maxUnresolvedQuestions
+        );
+        if (norm === null) return base;
+        return base + norm * 8;
+      })
+      .attr('fill', (d) => {
+        if (affectOverlayMode === 'off') return GROUP_COLORS[d.group] ?? '#6b7280';
+        const norm = normalizeMetricValue(
+          affectOverlayMode,
+          d.affect_overlay?.[affectOverlayMode],
+          maxUnresolvedQuestions
+        );
+        if (norm === null) return '#9ca3af';
+        return `rgb(${Math.round(34 + norm * 190)}, ${Math.round(197 - norm * 90)}, ${Math.round(94 - norm * 60)})`;
+      })
       .attr('stroke', '#fff')
       .attr('stroke-width', 1.5)
       .style('cursor', 'pointer')
@@ -281,8 +383,9 @@ export default function BrainMapGraph() {
             d.fy = null;
           })
       )
-      .on('click', (event) => {
+      .on('click', (event, d) => {
         event.stopPropagation();
+        setSelectedNodeId(d.id);
       });
 
     const labels = g
@@ -313,6 +416,16 @@ export default function BrainMapGraph() {
         if (d.compass_axis) extra.push(`Axis: ${d.compass_axis}`);
         if (d.grimoire_tags?.length) extra.push(`Tags: ${d.grimoire_tags.join(', ')}`);
         if (d.insight_level) extra.push(`Insight: ${d.insight_level}`);
+        if (d.affect_overlay) {
+          if (typeof d.affect_overlay.concern_level === 'number') extra.push(`Concern: ${d.affect_overlay.concern_level}`);
+          if (typeof d.affect_overlay.need_urgency === 'number') extra.push(`Urgency: ${d.affect_overlay.need_urgency}`);
+          if (typeof d.affect_overlay.accomplishment_momentum === 'number')
+            extra.push(`Momentum: ${d.affect_overlay.accomplishment_momentum}`);
+          if (typeof d.affect_overlay.unresolved_question_count === 'number')
+            extra.push(`Unresolved Q: ${d.affect_overlay.unresolved_question_count}`);
+          if (typeof d.affect_overlay.confidence_drift === 'number')
+            extra.push(`Confidence drift: ${d.affect_overlay.confidence_drift}`);
+        }
         const tail = extra.length ? `<br/>${extra.join('<br/>')}` : '';
         tooltip
           .style('visibility', 'visible')
@@ -336,7 +449,7 @@ export default function BrainMapGraph() {
     });
 
     return () => tooltip.remove();
-  }, [filteredData]);
+  }, [filteredData, affectOverlayMode, maxUnresolvedQuestions]);
 
   useEffect(() => {
     renderGraph();
@@ -347,6 +460,18 @@ export default function BrainMapGraph() {
     [filteredData]
   );
   const ogCols = useMemo(() => openGrimoireTableFlags(sortedNodes), [sortedNodes]);
+  const showAffectCols = useMemo(() => sortedNodes.some(hasAffectSignals), [sortedNodes]);
+  const selectedNode = useMemo(
+    () => sortedNodes.find((node) => node.id === selectedNodeId) ?? null,
+    [sortedNodes, selectedNodeId]
+  );
+  const connectedEdges = useMemo(
+    () =>
+      selectedNode
+        ? (filteredData?.edges ?? []).filter((edge) => edge.source === selectedNode.id || edge.target === selectedNode.id)
+        : [],
+    [filteredData, selectedNode]
+  );
 
   if (loading) {
     return (
@@ -428,6 +553,29 @@ export default function BrainMapGraph() {
             <span className="hidden text-gray-300 sm:inline" aria-hidden>
               |
             </span>
+            <span className="w-full text-xs font-medium uppercase tracking-wide text-gray-500 sm:w-auto">Affect overlay</span>
+            <select
+              aria-label="Affect overlay metric"
+              value={affectOverlayMode}
+              onChange={(event) => setAffectOverlayMode(event.target.value as AffectOverlayMode)}
+              className="min-h-[40px] rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700"
+            >
+              <option value="off">Off</option>
+              <option value="concern_level">Concern level</option>
+              <option value="need_urgency">Need urgency</option>
+              <option value="accomplishment_momentum">Accomplishment momentum</option>
+              <option value="unresolved_question_count">Unresolved question count</option>
+              <option value="confidence_drift">Confidence drift</option>
+            </select>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={affectFilterOnly}
+                onChange={(event) => setAffectFilterOnly(event.target.checked)}
+                data-testid="affect-filter-checkbox"
+              />
+              Show affect-only
+            </label>
             <span className="w-full text-xs font-medium uppercase tracking-wide text-gray-500 sm:w-auto">Layer</span>
             {(['all', 'state', 'vault'] as const).map((lf) => (
               <button
@@ -515,14 +663,36 @@ export default function BrainMapGraph() {
                       Insight level
                     </th>
                   )}
+                  {showAffectCols && (
+                    <>
+                      <th scope="col" className="px-4 py-2 font-semibold text-gray-900">
+                        Concern
+                      </th>
+                      <th scope="col" className="px-4 py-2 font-semibold text-gray-900">
+                        Urgency
+                      </th>
+                      <th scope="col" className="px-4 py-2 font-semibold text-gray-900">
+                        Momentum
+                      </th>
+                      <th scope="col" className="px-4 py-2 font-semibold text-gray-900">
+                        Unresolved questions
+                      </th>
+                      <th scope="col" className="px-4 py-2 font-semibold text-gray-900">
+                        Confidence drift
+                      </th>
+                    </>
+                  )}
                 </tr>
               </thead>
               <tbody>
                 {sortedNodes.map((node) => (
                   <tr
                     key={node.id}
-                    className="border-b border-gray-100 hover:bg-gray-50 focus-within:bg-blue-50"
+                    className={`border-b border-gray-100 hover:bg-gray-50 focus-within:bg-blue-50 ${
+                      selectedNodeId === node.id ? 'bg-blue-50' : ''
+                    }`}
                     tabIndex={0}
+                    onClick={() => setSelectedNodeId(node.id)}
                   >
                     <td className="px-4 py-2 font-mono text-gray-800">{node.path}</td>
                     <td className="px-4 py-2">
@@ -550,11 +720,75 @@ export default function BrainMapGraph() {
                     {ogCols.insight_level && (
                       <td className="px-4 py-2">{node.insight_level ?? '—'}</td>
                     )}
+                    {showAffectCols && (
+                      <>
+                        <td className="px-4 py-2">{node.affect_overlay?.concern_level ?? '—'}</td>
+                        <td className="px-4 py-2">{node.affect_overlay?.need_urgency ?? '—'}</td>
+                        <td className="px-4 py-2">{node.affect_overlay?.accomplishment_momentum ?? '—'}</td>
+                        <td className="px-4 py-2">{node.affect_overlay?.unresolved_question_count ?? '—'}</td>
+                        <td className="px-4 py-2">{node.affect_overlay?.confidence_drift ?? '—'}</td>
+                      </>
+                    )}
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
+        )}
+        {selectedNode && (
+          <aside
+            className="border-t border-gray-200 bg-white p-4"
+            data-testid="intent-drilldown-panel"
+            aria-label="Intent artifacts drilldown"
+          >
+            <h2 className="text-sm font-semibold text-gray-900">Intent drilldown</h2>
+            <p className="mt-1 text-xs text-gray-600">
+              Node: <code className="rounded bg-gray-100 px-1">{selectedNode.path}</code>
+            </p>
+            {selectedNode.affect_overlay && (
+              <div className="mt-2 text-xs text-gray-700">
+                {(['concern_level', 'need_urgency', 'accomplishment_momentum', 'unresolved_question_count', 'confidence_drift'] as AffectMetricKey[]).map((key) => (
+                  <span key={key} className="mr-3 inline-block">
+                    {metricLabel(key)}: {selectedNode.affect_overlay?.[key] ?? '—'}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="mt-3 text-sm">
+              <p className="font-medium text-gray-900">Intent artifacts</p>
+              <ul className="ml-4 list-disc text-gray-700">
+                <li data-testid="intent-survey-refs">
+                  Survey refs: {selectedNode.intent_artifacts?.survey_refs?.join(', ') || '—'}
+                </li>
+                <li>
+                  Clarification refs: {selectedNode.intent_artifacts?.clarification_refs?.join(', ') || '—'}
+                </li>
+                <li>
+                  Alignment context refs:{' '}
+                  {selectedNode.intent_artifacts?.alignment_context_refs?.join(', ') || '—'}
+                </li>
+              </ul>
+            </div>
+            {connectedEdges.length > 0 && (
+              <div className="mt-3">
+                <p className="text-sm font-medium text-gray-900">Session links</p>
+                <ul className="ml-4 list-disc text-xs text-gray-700">
+                  {connectedEdges.map((edge, idx) => (
+                    <li key={`${edge.source}-${edge.target}-${idx}`}>
+                      {(edge.sessions ?? []).join(', ') || '—'}
+                      {edge.affect_by_session &&
+                        ` (session affect overlays: ${Object.keys(edge.affect_by_session).join(', ')})`}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {!hasIntentArtifacts(selectedNode) && (
+              <p className="mt-2 text-xs text-gray-500">
+                No linked survey, clarification, or alignment references on this node.
+              </p>
+            )}
+          </aside>
         )}
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Surface intent and collaboration signals (affect/intent artifacts) alongside the existing file/path co-access topology so operators can reason about concern, urgency, momentum and unresolved issues per node/session. 
- Provide a lightweight, backward-compatible overlay model that can be toggled and filtered in the viewer without breaking legacy graphs. 
- Offer a drilldown view that links nodes/sessions to underlying intent artifacts (survey, clarification, alignment context) for quicker operator follow-up.

### Description
- Added an affect overlay and intent artifacts schema to node/edge types (`affect_overlay`, `intent_artifacts`, `affect_by_session`, `intent_artifacts_by_session`) and related TypeScript interfaces in `src/components/BrainMap/BrainMapGraph.tsx` and documented the new optional fields in `docs/BRAIN_MAP_SCHEMA.md` with backward-compatible rules. 
- Extended `BrainMapGraph` to expose an `Affect overlay` selector, an `Show affect-only` filter, and logic to normalize/display overlay metrics as node color/size modifiers while remaining safe when fields are absent. 
- Enhanced the table view to show affect columns (`Concern`, `Urgency`, `Momentum`, `Unresolved questions`, `Confidence drift`) only when affect data exists, and added click/select handling to surface a drilldown panel. 
- Implemented an intent drilldown panel that shows a selected node’s affect metric values, `survey_refs`, `clarification_refs`, `alignment_context_refs`, session links, and per-session overlay presence. 
- Added e2e fixture updates (`e2e/fixtures/brain-map-state-only.json`) with affect + intent metadata and new Playwright checks in `e2e/context-atlas.spec.ts` to validate overlay columns, drilldown visibility, and affect-only filter behavior.

### Testing
- Ran `npm run type-check` and it completed successfully. 
- Ran `npm run lint -- src/components/BrainMap/BrainMapGraph.tsx e2e/context-atlas.spec.ts` which failed because the `next lint` invocation in this environment errored before linting due to project-root expectations (the CLI requires a root invocation in this setup). 
- Ran `npm run test:e2e -- e2e/context-atlas.spec.ts` which executed the Playwright suite but failed to start browsers in this environment because Playwright browser binaries are not installed (Playwright reported missing executable) and the server logged a Google Fonts fetch warning; tests could be re-run after `npx playwright install` and network/font availability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabb68dc8c832ca4e6b944cfb62f9b)