### PR TITLE
Add chunked brain-map API, ETag caching, and web-worker force layout

### DIFF
--- a/src/app/api/brain-map/graph/route.ts
+++ b/src/app/api/brain-map/graph/route.ts
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { createHash } from 'crypto';
 import {
   OPENGRIMOIRE_SESSION_COOKIE,
   verifyAdminSessionToken,
@@ -46,8 +47,50 @@ export async function GET(request: Request) {
       raw = await readFile(defaultPath, 'utf-8');
     }
     const graph = JSON.parse(raw);
+    const url = new URL(request.url);
+    const chunkSize = Math.max(0, Number.parseInt(url.searchParams.get('chunkSize') ?? '0', 10) || 0);
+    const chunkIndex = Math.max(0, Number.parseInt(url.searchParams.get('chunkIndex') ?? '0', 10) || 0);
+
+    const fingerprint = createHash('sha1').update(raw).digest('hex');
+    const etag = `W/\"brain-map-${fingerprint}\"`;
+    if (request.headers.get('if-none-match') === etag) {
+      return new NextResponse(null, {
+        status: 304,
+        headers: {
+          ETag: etag,
+          'Cache-Control': 'public, max-age=0, must-revalidate',
+        },
+      });
+    }
+
+    if (chunkSize > 0) {
+      const nodeStart = chunkIndex * chunkSize;
+      const edgeStart = chunkIndex * chunkSize;
+      const chunked = {
+        ...graph,
+        nodes: graph.nodes.slice(nodeStart, nodeStart + chunkSize),
+        edges: graph.edges.slice(edgeStart, edgeStart + chunkSize),
+        chunkIndex,
+        chunkSize,
+        hasMoreNodes: nodeStart + chunkSize < graph.nodes.length,
+        hasMoreEdges: edgeStart + chunkSize < graph.edges.length,
+        fingerprint,
+      };
+      return NextResponse.json(chunked, {
+        headers: {
+          ETag: etag,
+          'Cache-Control': 'public, max-age=0, must-revalidate',
+          'X-Graph-Fingerprint': fingerprint,
+        },
+      });
+    }
+
     return NextResponse.json(graph, {
-      headers: { 'Cache-Control': 'no-store' },
+      headers: {
+        ETag: etag,
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+        'X-Graph-Fingerprint': fingerprint,
+      },
     });
   } catch {
     return NextResponse.json(

--- a/src/components/BrainMap/BrainMapGraph.tsx
+++ b/src/components/BrainMap/BrainMapGraph.tsx
@@ -79,6 +79,7 @@ export interface BrainMapData {
 }
 
 type GraphNode = BrainMapNode & d3Force.SimulationNodeDatum;
+type LayoutPosition = { id: string; x: number; y: number };
 type GraphLink = Omit<BrainMapEdge, 'source' | 'target'> & d3Force.SimulationLinkDatum<GraphNode>;
 type AffectMetricKey =
   | 'concern_level'
@@ -236,6 +237,7 @@ export default function BrainMapGraph() {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   /** True when API returned 200 but no nodes (empty build); UI shows placeholder graph — use All/State layer, or rebuild JSON. */
   const [placeholderFromEmptyApi, setPlaceholderFromEmptyApi] = useState(false);
+  const [layoutPositions, setLayoutPositions] = useState<Record<string, LayoutPosition>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -246,21 +248,45 @@ export default function BrainMapGraph() {
     }
     setLoading(true);
     setError(null);
-    const url = `/api/brain-map/graph?cb=${Date.now()}`;
-    fetch(url, { headers, credentials: 'include', cache: 'no-store' })
-      .then((res) => {
-        return res.ok ? res.json() : Promise.reject(new Error(`${res.status} ${res.statusText}`));
-      })
-      .then((graph: BrainMapData) => {
-        if (cancelled) return;
-        if (graph.nodes?.length > 0) {
-          setPlaceholderFromEmptyApi(false);
-          setData(graph);
-        } else {
-          setPlaceholderFromEmptyApi((graph.sessionCount ?? 0) === 0);
-          setData(EMPTY_GRAPH);
-        }
-      })
+    const chunkSize = 500;
+    const fetchChunk = async (chunkIndex: number): Promise<BrainMapData & { hasMoreNodes?: boolean; hasMoreEdges?: boolean }> => {
+      const url = `/api/brain-map/graph?chunkSize=${chunkSize}&chunkIndex=${chunkIndex}`;
+      const res = await fetch(url, { headers, credentials: 'include', cache: 'default' });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      return res.json();
+    };
+
+    (async () => {
+      const chunks: BrainMapData[] = [];
+      let chunkIndex = 0;
+      while (!cancelled) {
+        const chunk = await fetchChunk(chunkIndex);
+        chunks.push(chunk);
+        const hasMore = Boolean(chunk.hasMoreNodes || chunk.hasMoreEdges);
+        if (!hasMore) break;
+        chunkIndex += 1;
+      }
+      if (cancelled) return;
+      const graph = chunks.reduce<BrainMapData>(
+        (acc, chunk) => ({
+          ...acc,
+          generated: chunk.generated,
+          sessionCount: chunk.sessionCount,
+          sourceRoots: chunk.sourceRoots,
+          nodes: acc.nodes.concat(chunk.nodes ?? []),
+          edges: acc.edges.concat(chunk.edges ?? []),
+        }),
+        { nodes: [], edges: [], generated: '', sessionCount: 0 }
+      );
+
+      if (graph.nodes?.length > 0) {
+        setPlaceholderFromEmptyApi(false);
+        setData(graph);
+      } else {
+        setPlaceholderFromEmptyApi((graph.sessionCount ?? 0) === 0);
+        setData(EMPTY_GRAPH);
+      }
+    })()
       .catch((err: unknown) => {
         if (cancelled) return;
         const msg = err instanceof Error ? err.message : 'Failed to load graph';
@@ -322,6 +348,22 @@ export default function BrainMapGraph() {
     return { state: 'stale', label: 'Stale (>72h)' };
   }, [data?.generated]);
 
+
+  useEffect(() => {
+    if (!filteredData || !svgRef.current || typeof Worker === 'undefined') return;
+    const worker = new Worker(new URL('./brainMapLayout.worker.ts', import.meta.url));
+    const width = svgRef.current.clientWidth || 800;
+    const height = svgRef.current.clientHeight || 600;
+    worker.postMessage({ nodes: filteredData.nodes, edges: filteredData.edges, width, height });
+    worker.onmessage = (event: MessageEvent<{ nodes: LayoutPosition[] }>) => {
+      const next: Record<string, LayoutPosition> = {};
+      for (const node of event.data.nodes) next[node.id] = node;
+      setLayoutPositions(next);
+      worker.terminate();
+    };
+    return () => worker.terminate();
+  }, [filteredData]);
+
   const renderGraph = useCallback(() => {
     if (!svgRef.current || !filteredData) return;
 
@@ -330,7 +372,7 @@ export default function BrainMapGraph() {
 
     select(svgRef.current).selectAll('*').remove();
 
-    const nodes: GraphNode[] = filteredData.nodes.map((n) => ({ ...n, x: 0, y: 0 }));
+    const nodes: GraphNode[] = filteredData.nodes.map((n) => ({ ...n, x: layoutPositions[n.id]?.x ?? 0, y: layoutPositions[n.id]?.y ?? 0 }));
     const links: GraphLink[] = filteredData.edges.map((e) => ({
       ...e,
       source: nodes.find((nn) => nn.id === e.source) ?? e.source,
@@ -477,7 +519,7 @@ export default function BrainMapGraph() {
     });
 
     return () => tooltip.remove();
-  }, [filteredData, affectOverlayMode, maxUnresolvedQuestions]);
+  }, [filteredData, affectOverlayMode, maxUnresolvedQuestions, layoutPositions]);
 
   useEffect(() => {
     renderGraph();

--- a/src/components/BrainMap/brainMapLayout.worker.ts
+++ b/src/components/BrainMap/brainMapLayout.worker.ts
@@ -1,0 +1,34 @@
+import * as d3Force from 'd3-force';
+
+type WorkerNode = { id: string; x?: number; y?: number };
+type WorkerEdge = { source: string; target: string; weight?: number };
+
+type WorkerMessage = {
+  nodes: WorkerNode[];
+  edges: WorkerEdge[];
+  width: number;
+  height: number;
+};
+
+self.onmessage = (event: MessageEvent<WorkerMessage>) => {
+  const { nodes, edges, width, height } = event.data;
+  const simNodes = nodes.map((node) => ({ ...node, x: width / 2, y: height / 2 }));
+  const links = edges.map((edge) => ({
+    ...edge,
+    source: simNodes.find((node) => node.id === edge.source) ?? edge.source,
+    target: simNodes.find((node) => node.id === edge.target) ?? edge.target,
+  }));
+
+  const simulation = d3Force
+    .forceSimulation(simNodes)
+    .force('link', d3Force.forceLink(links).id((d: any) => d.id).distance(80))
+    .force('charge', d3Force.forceManyBody().strength(-200))
+    .force('center', d3Force.forceCenter(width / 2, height / 2))
+    .stop();
+
+  for (let i = 0; i < 120; i += 1) simulation.tick();
+
+  (self as DedicatedWorkerGlobalScope).postMessage({
+    nodes: simNodes.map((node) => ({ id: node.id, x: node.x ?? 0, y: node.y ?? 0 })),
+  });
+};


### PR DESCRIPTION
### Motivation
- Large context-atlas JSONs caused main-thread jank and slow reloads, so graph hydration must be incremental and heavy layout work moved off the UI thread. 
- Client-side caching using immutable fingerprints and `ETag` lets browsers avoid re-downloading identical graph payloads and enables fast reloads. 

### Description
- Updated `GET /api/brain-map/graph` (`src/app/api/brain-map/graph/route.ts`) to support `chunkSize` and `chunkIndex` query params for chunked responses and to return chunk metadata (`hasMoreNodes`, `hasMoreEdges`).
- Added stable fingerprinting and conditional caching via `ETag` + `If-None-Match` and an `X-Graph-Fingerprint` header so clients can receive `304` when the graph is unchanged.
- Changed the brain-map loader in `src/components/BrainMap/BrainMapGraph.tsx` to fetch the graph in chunks (default chunk size 500), progressively assemble `nodes`/`edges`, and keep backward compatibility when no chunk params are used.
- Introduced a dedicated web worker `src/components/BrainMap/brainMapLayout.worker.ts` to precompute D3 force-layout ticks and wired the component to consume `layoutPositions` so initial render uses worker-provided node coordinates to reduce main-thread layout work.

### Testing
- Ran TypeScript checks with `npm run type-check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce58efdb4832c8ffd4a370df97201)