### PR TITLE
fix: gitleaks allowlist and CI secret scan

### DIFF
--- a/.github/workflows/security-gitleaks.yml
+++ b/.github/workflows/security-gitleaks.yml
@@ -1,0 +1,30 @@
+name: Secret Scan (Gitleaks)
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_SUMMARY: true
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+title = "Gitleaks configuration"
+
+[allowlist]
+description = "Docs, binaries, local dev env, and build artifacts."
+paths = [
+  '''.*\.md$''',
+  '''.*\.lock$''',
+  '''.*\.svg$''',
+  '''.*\.png$''',
+  '''.*\.jpg$''',
+  '''.*\.jpeg$''',
+  '''.*\.gif$''',
+  '''.*\.pdf$''',
+  '''.*\.min\.js$''',
+  '''.*\.map$''',
+  '''\.next/''',
+  '''\.env\.local$''',
+  '''\.env\..*\.local$''',
+  '''out/''',
+  '''/data/''',
+  '''playwright-report/''',
+  '''test-results/'''
+]


### PR DESCRIPTION
## Summary
- Add .gitleaks.toml (allowlist .next, .env.local, build/test artifacts)
- Add security-gitleaks.yml CI workflow (master + main)

## Test plan
- [x] gitleaks detect --config .gitleaks.toml --no-git (pass)

## Note
.env.local is gitignored; removed from tree in f43be53. Rotate local secrets if old .env.local values may exist in git history.

Made with [Cursor](https://cursor.com)