### PR TITLE
feat(decision-chain): API and pane over local decision-graph SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ public/brain-map-graph.local.json.*
 public/wiki/**
 !public/wiki/.gitkeep
 
-# Local SQLite (alignment + survey)
-/data/
+# Local SQLite (alignment + survey + decision graph); keep README tracked
+/data/**
+!/data/README.md
 
 # Private consulting / strategy research (not shipped in public clone; see docs/research/PRIVATE_RESEARCH_LAYOUT.md)
 /docs/private/

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,17 @@
+# OpenGrimoire `data/` (local only)
+
+This directory holds **gitignored** local SQLite files:
+
+- `decision-graph.sqlite` — decision graph projection (see [DECISION_GRAPH_SCHEMA.md](../docs/DECISION_GRAPH_SCHEMA.md))
+- Other app SQLite (alignment / survey) as already used by the server
+
+**Do not commit** `*.sqlite`. Rebuild the decision graph:
+
+```bash
+# From MiscRepos (adjust paths)
+set DECISION_LOG_PATH=...\.cursor\state\decision-log.md
+set DECISION_GRAPH_DB=%CD%\..\OpenGrimoire\data\decision-graph.sqlite
+python .cursor\scripts\project_decision_graph.py
+```
+
+Markdown `decision-log.md` remains the human-append SSOT.

--- a/docs/DECISION_GRAPH_SCHEMA.md
+++ b/docs/DECISION_GRAPH_SCHEMA.md
@@ -1,0 +1,113 @@
+# Decision graph schema (local DI store)
+
+**PURPOSE:** Typed decision nodes + causal edges projected from harness markdown. Not a Semantica runtime; adapt-not-adopt.
+
+**SSOT:** Human append remains OpenHarness / MiscRepos `decision-log.md`. SQLite is a **projection** + edge store (KTD1).
+
+**DB path:** `data/decision-graph.sqlite` under OpenGrimoire (gitignored). Override with `DECISION_GRAPH_DB`.
+
+**Projector:** `MiscRepos/.cursor/scripts/project_decision_graph.py`
+
+---
+
+## Edge types (closed enum)
+
+Only:
+
+| Type | Meaning |
+|------|---------|
+| `CAUSED` | Source decision directly caused the target |
+| `INFLUENCED` | Source influenced the target |
+| `PRECEDENT_FOR` | Source is a precedent for the target |
+
+Any other type is **rejected** (no write).
+
+---
+
+## SQLite tables
+
+### `meta`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `key` | TEXT PK | e.g. `generated`, `schema_version`, `source_log` |
+| `value` | TEXT | |
+
+`schema_version` = `1`. `generated` = ISO-8601 UTC when last projected.
+
+### `decisions`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Stable id (see below) |
+| `date` | TEXT | `YYYY-MM-DD` from section heading |
+| `area` | TEXT | Bracket area from entry |
+| `decision` | TEXT NOT NULL | One-line decision text |
+| `rationale` | TEXT | Optional |
+| `plan_ref` | TEXT | Optional `(plan: …)` |
+| `source_path` | TEXT | Path of decision-log file |
+| `created_at` | TEXT | Projection timestamp (ISO UTC) |
+
+### `edges`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `source_id` | TEXT NOT NULL | FK-like to `decisions.id` |
+| `target_id` | TEXT NOT NULL | |
+| `edge_type` | TEXT NOT NULL | CHECK enum above |
+| UNIQUE(`source_id`, `target_id`, `edge_type`) | | |
+
+---
+
+## Stable decision ID
+
+```
+id = "d_" + sha256(f"{date}\n{area}\n{decision}").hexdigest()[:16]
+```
+
+Same prose under the same date/area → same id across idempotent rebuilds. Changing the decision line creates a new id (old row removed on full rebuild).
+
+---
+
+## decision-log.md mapping
+
+Per [OpenHarness `state/README.md`](../../OpenHarness/state/README.md) (sibling):
+
+- Section: `## YYYY-MM-DD`
+- Entry: `- **[Area]** Decision: <one-line>. Rationale: <optional>.` Optional: `(plan: <name or path>)`
+
+Critic / intent-alignment JSON may be mapped in a later projector version; v1 projects **decision-log prose only**.
+
+---
+
+## Edges JSONL sidecar
+
+Path: `DECISION_EDGES_JSONL` or `<state-dir>/decision-graph-edges.jsonl`.
+
+One JSON object per line:
+
+```json
+{"source_id":"d_abc…","target_id":"d_def…","type":"CAUSED"}
+```
+
+Aliases accepted: `from`/`to`, `source`/`target`, `relationship_type` for `type`.
+
+Edges whose endpoints are missing after projection are skipped with a warning (not a hard fail). Invalid `type` → hard fail, no DB write.
+
+---
+
+## Non-goals
+
+- Semantica / Neo4j / Rete / Datalog / lakehouse connectors
+- Replacing SCP quarantine
+- Making Arcforge / LLM-Wiki a graph database
+- Second write-primary for operators (do not require SQL to log decisions)
+
+---
+
+## Related
+
+- Brain-map co-access: [BRAIN_MAP_SCHEMA.md](./BRAIN_MAP_SCHEMA.md)
+- Program plan: `local-proto/docs/plans/2026-08-12-001-feat-decision-graph-adapt-program-plan.md`
+- Comparison: `local-proto/docs/adhoc/2026-08-12-semantica-portfolio-comparison.md`

--- a/src/app/api/decision-graph/route.test.ts
+++ b/src/app/api/decision-graph/route.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { GET } from './route';
+
+describe('GET /api/decision-graph', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dg-'));
+    dbPath = join(dir, 'decision-graph.sqlite');
+    process.env.DECISION_GRAPH_DB = dbPath;
+    process.env.DECISION_CONFLICT_FLAGS = join(dir, 'conflict-flags.json');
+  });
+
+  afterEach(() => {
+    delete process.env.DECISION_GRAPH_DB;
+    delete process.env.DECISION_CONFLICT_FLAGS;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns missing status when db absent', async () => {
+    const res = await GET(new Request('http://localhost/api/decision-graph'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('missing');
+    expect(body.decisions).toEqual([]);
+  });
+
+  it('returns chain for fixture decisions', async () => {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE decisions (
+        id TEXT PRIMARY KEY, date TEXT, area TEXT, decision TEXT NOT NULL,
+        rationale TEXT, plan_ref TEXT, source_path TEXT, created_at TEXT
+      );
+      CREATE TABLE edges (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source_id TEXT NOT NULL, target_id TEXT NOT NULL, edge_type TEXT NOT NULL
+      );
+    `);
+    db.prepare(
+      `INSERT INTO decisions (id, date, area, decision) VALUES (?, ?, ?, ?)`
+    ).run('d_a', '2026-08-01', 'A', 'First');
+    db.prepare(
+      `INSERT INTO decisions (id, date, area, decision) VALUES (?, ?, ?, ?)`
+    ).run('d_b', '2026-08-02', 'B', 'Second');
+    db.prepare(
+      `INSERT INTO edges (source_id, target_id, edge_type) VALUES (?, ?, ?)`
+    ).run('d_a', 'd_b', 'CAUSED');
+    db.close();
+
+    const list = await GET(new Request('http://localhost/api/decision-graph'));
+    const listBody = await list.json();
+    expect(listBody.status).toBe('ok');
+    expect(listBody.decisions).toHaveLength(2);
+
+    const chainRes = await GET(
+      new Request('http://localhost/api/decision-graph?id=d_b')
+    );
+    const chainBody = await chainRes.json();
+    expect(chainBody.status).toBe('ok');
+    expect(chainBody.chain.map((d: { id: string }) => d.id)).toEqual(['d_a', 'd_b']);
+  });
+
+  it('returns 500 for corrupt db without stack leak shape', async () => {
+    writeFileSync(dbPath, 'not-a-sqlite-file');
+    const res = await GET(new Request('http://localhost/api/decision-graph'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.status).toBe('error');
+    expect(body.message).toMatch(/Corrupt|unreadable/i);
+  });
+});

--- a/src/app/api/decision-graph/route.ts
+++ b/src/app/api/decision-graph/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { readDecisionGraph, traceDecisionChain } from '@/lib/decision-graph/read';
+
+/**
+ * GET /api/decision-graph — list decisions/edges or ?id= for a chain.
+ * Reads gitignored data/decision-graph.sqlite when present.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const id = url.searchParams.get('id');
+
+  if (id) {
+    const result = traceDecisionChain(id);
+    if (result.status === 'missing') {
+      return NextResponse.json(
+        {
+          status: 'missing',
+          message: 'No decision-graph.sqlite yet. Run project_decision_graph.py',
+          chain: [],
+          edges: [],
+        },
+        { status: 200 }
+      );
+    }
+    if (result.status === 'unknown') {
+      return NextResponse.json(
+        { status: 'unknown', message: 'Unknown decision id', chain: [], edges: [] },
+        { status: 404 }
+      );
+    }
+    if (result.status === 'error') {
+      return NextResponse.json(
+        { status: 'error', message: 'Corrupt or unreadable decision graph', error: result.error },
+        { status: 500 }
+      );
+    }
+    return NextResponse.json(
+      { status: 'ok', chain: result.chain, edges: result.edges },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+
+  const graph = readDecisionGraph();
+  if (graph.status === 'error') {
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: 'Corrupt or unreadable decision graph',
+        error: graph.error,
+        decisions: [],
+        edges: [],
+        callouts: [],
+      },
+      { status: 500 }
+    );
+  }
+  return NextResponse.json(
+    {
+      status: graph.status,
+      decisions: graph.decisions,
+      edges: graph.edges,
+      meta: graph.meta,
+      callouts: graph.callouts,
+      message:
+        graph.status === 'missing'
+          ? 'No decision-graph.sqlite yet. Run MiscRepos/.cursor/scripts/project_decision_graph.py'
+          : undefined,
+    },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/src/app/decision-chain/page.tsx
+++ b/src/app/decision-chain/page.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+type Decision = {
+  id: string;
+  date: string | null;
+  area: string | null;
+  decision: string;
+  rationale: string | null;
+};
+
+type Edge = { source_id: string; target_id: string; type: string };
+
+type Callout = { id: string; summary: string; paths?: string[] };
+
+type GraphPayload = {
+  status: string;
+  message?: string;
+  decisions: Decision[];
+  edges: Edge[];
+  callouts?: Callout[];
+  meta?: Record<string, string>;
+};
+
+/**
+ * PURPOSE: Decision-chain pane with timeline scrub + conflict callout slots (U4/U5)
+ */
+export default function DecisionChainPage() {
+  const [data, setData] = useState<GraphPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [chain, setChain] = useState<Decision[]>([]);
+  const [chainEdges, setChainEdges] = useState<Edge[]>([]);
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch('/api/decision-graph', { cache: 'no-store' });
+      const json = (await res.json()) as GraphPayload;
+      if (res.status >= 500) {
+        setError(json.message ?? 'Failed to load decision graph');
+        setData(json);
+        return;
+      }
+      setData(json);
+      if (json.decisions?.length && !selectedId) {
+        setSelectedId(json.decisions[0].id);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [selectedId]);
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setChain([]);
+      setChainEdges([]);
+      return;
+    }
+    void (async () => {
+      const res = await fetch(`/api/decision-graph?id=${encodeURIComponent(selectedId)}`, {
+        cache: 'no-store',
+      });
+      const json = await res.json();
+      setChain(json.chain ?? []);
+      setChainEdges(json.edges ?? []);
+    })();
+  }, [selectedId]);
+
+  const datesPresent = useMemo(() => {
+    const dates = (data?.decisions ?? [])
+      .map((d) => d.date)
+      .filter((d): d is string => Boolean(d));
+    return dates.length > 0;
+  }, [data]);
+
+  const filtered = useMemo(() => {
+    const list = data?.decisions ?? [];
+    if (!datesPresent) return list;
+    return list.filter((d) => {
+      if (!d.date) return true;
+      if (fromDate && d.date < fromDate) return false;
+      if (toDate && d.date > toDate) return false;
+      return true;
+    });
+  }, [data, fromDate, toDate, datesPresent]);
+
+  const callouts = data?.callouts ?? [];
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <h1 className="text-xl font-semibold">Decision chain</h1>
+        <Link href="/brain-map" className="text-sm underline">
+          Context atlas / brain-map
+        </Link>
+      </header>
+
+      {error ? (
+        <p className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-900" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {data?.status === 'missing' ? (
+        <p className="rounded border border-amber-400 bg-amber-50 p-3 text-sm">
+          {data.message ?? 'No decision graph yet.'} Atlas still works at{' '}
+          <Link href="/brain-map" className="underline">
+            /brain-map
+          </Link>
+          .
+        </p>
+      ) : null}
+
+      <section aria-label="Conflict and entity callouts" className="rounded border p-3">
+        <h2 className="mb-2 text-sm font-medium">Callouts</h2>
+        {callouts.length === 0 ? (
+          <p className="text-sm opacity-70">No conflict flags (slot ready for Phase D).</p>
+        ) : (
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {callouts.map((c) => (
+              <li key={c.id}>
+                {c.summary}
+                {c.paths?.length ? (
+                  <span className="opacity-70"> — {c.paths.join(', ')}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-label="Timeline scrub" className="flex flex-wrap items-end gap-3 rounded border p-3">
+        <h2 className="w-full text-sm font-medium">Timeline</h2>
+        {!datesPresent ? (
+          <p className="text-sm opacity-70">No dates on decisions — scrub disabled; showing all.</p>
+        ) : (
+          <>
+            <label className="text-sm">
+              From{' '}
+              <input
+                type="date"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+                className="ml-1 border px-1"
+              />
+            </label>
+            <label className="text-sm">
+              To{' '}
+              <input
+                type="date"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
+                className="ml-1 border px-1"
+              />
+            </label>
+          </>
+        )}
+      </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <section aria-label="Decisions" className="rounded border p-3">
+          <h2 className="mb-2 text-sm font-medium">Decisions ({filtered.length})</h2>
+          <ul className="max-h-96 space-y-2 overflow-auto text-sm">
+            {filtered.map((d) => (
+              <li key={d.id}>
+                <button
+                  type="button"
+                  className={`w-full rounded px-2 py-1 text-left hover:bg-black/5 ${
+                    selectedId === d.id ? 'bg-black/10 font-medium' : ''
+                  }`}
+                  onClick={() => setSelectedId(d.id)}
+                >
+                  <span className="opacity-70">{d.date ?? '—'}</span> [{d.area}] {d.decision}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section aria-label="Selected chain" className="rounded border p-3">
+          <h2 className="mb-2 text-sm font-medium">Chain</h2>
+          {chain.length === 0 ? (
+            <p className="text-sm opacity-70">Select a decision to see causal ancestry.</p>
+          ) : (
+            <ol className="list-decimal space-y-2 pl-5 text-sm">
+              {chain.map((d) => (
+                <li key={d.id}>
+                  <strong>[{d.area}]</strong> {d.decision}
+                  {d.rationale ? <div className="opacity-70">Rationale: {d.rationale}</div> : null}
+                </li>
+              ))}
+            </ol>
+          )}
+          {chainEdges.length > 0 ? (
+            <ul className="mt-3 space-y-1 text-xs opacity-80">
+              {chainEdges.map((e, i) => (
+                <li key={`${e.source_id}-${e.target_id}-${e.type}-${i}`}>
+                  {e.type}: {e.source_id.slice(0, 10)}… → {e.target_id.slice(0, 10)}…
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/decision-graph/read.ts
+++ b/src/lib/decision-graph/read.ts
@@ -1,0 +1,143 @@
+/**
+ * PURPOSE: Read-only access to decision-graph.sqlite projection
+ * DEPENDENCIES: better-sqlite3
+ * MODIFICATION NOTES: Adapt program U4 — separate from app survey SQLite
+ */
+
+import Database from 'better-sqlite3';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export type DecisionRow = {
+  id: string;
+  date: string | null;
+  area: string | null;
+  decision: string;
+  rationale: string | null;
+  plan_ref: string | null;
+  source_path: string | null;
+  created_at: string | null;
+};
+
+export type EdgeRow = {
+  source_id: string;
+  target_id: string;
+  type: string;
+};
+
+export type ConflictCallout = {
+  id: string;
+  summary: string;
+  paths?: string[];
+};
+
+export function decisionGraphDbPath(): string {
+  if (process.env.DECISION_GRAPH_DB) return process.env.DECISION_GRAPH_DB;
+  return join(process.cwd(), 'data', 'decision-graph.sqlite');
+}
+
+export function conflictFlagsPath(): string {
+  if (process.env.DECISION_CONFLICT_FLAGS) return process.env.DECISION_CONFLICT_FLAGS;
+  return join(process.cwd(), 'data', 'conflict-flags.json');
+}
+
+export function readDecisionGraph(): {
+  status: 'ok' | 'missing' | 'error';
+  error?: string;
+  decisions: DecisionRow[];
+  edges: EdgeRow[];
+  meta: Record<string, string>;
+  callouts: ConflictCallout[];
+} {
+  const dbPath = decisionGraphDbPath();
+  if (!existsSync(dbPath)) {
+    return { status: 'missing', decisions: [], edges: [], meta: {}, callouts: readCallouts() };
+  }
+  try {
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    try {
+      const decisions = db
+        .prepare(
+          `SELECT id, date, area, decision, rationale, plan_ref, source_path, created_at
+           FROM decisions ORDER BY date DESC, area ASC`
+        )
+        .all() as DecisionRow[];
+      const edges = db
+        .prepare(
+          `SELECT source_id, target_id, edge_type AS type FROM edges ORDER BY id ASC`
+        )
+        .all() as EdgeRow[];
+      const metaRows = db.prepare(`SELECT key, value FROM meta`).all() as {
+        key: string;
+        value: string;
+      }[];
+      const meta: Record<string, string> = {};
+      for (const row of metaRows) meta[row.key] = row.value;
+      return { status: 'ok', decisions, edges, meta, callouts: readCallouts() };
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      status: 'error',
+      error: message,
+      decisions: [],
+      edges: [],
+      meta: {},
+      callouts: [],
+    };
+  }
+}
+
+export function traceDecisionChain(leafId: string): {
+  status: 'ok' | 'missing' | 'unknown' | 'error';
+  error?: string;
+  chain: DecisionRow[];
+  edges: EdgeRow[];
+} {
+  const graph = readDecisionGraph();
+  if (graph.status === 'missing') return { status: 'missing', chain: [], edges: [] };
+  if (graph.status === 'error') {
+    return { status: 'error', error: graph.error, chain: [], edges: [] };
+  }
+  const byId = new Map(graph.decisions.map((d) => [d.id, d]));
+  if (!byId.has(leafId)) return { status: 'unknown', chain: [], edges: [] };
+
+  const visited: string[] = [];
+  const seen = new Set<string>();
+  const queue = [leafId];
+  const usedEdges: EdgeRow[] = [];
+  while (queue.length) {
+    const current = queue.shift()!;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    visited.push(current);
+    for (const e of graph.edges) {
+      if (e.target_id === current) {
+        usedEdges.push(e);
+        if (!seen.has(e.source_id)) queue.push(e.source_id);
+      }
+    }
+  }
+  const chainIds = [...visited].reverse();
+  return {
+    status: 'ok',
+    chain: chainIds.map((id) => byId.get(id)!).filter(Boolean),
+    edges: usedEdges,
+  };
+}
+
+function readCallouts(): ConflictCallout[] {
+  const path = conflictFlagsPath();
+  if (!existsSync(path)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as
+      | { flags?: ConflictCallout[] }
+      | ConflictCallout[];
+    if (Array.isArray(raw)) return raw;
+    return raw.flags ?? [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- `GET /api/decision-graph` (+ `?id=` chain) over gitignored `data/decision-graph.sqlite`
- `/decision-chain` pane: timeline scrub, conflict callout slots, link to brain-map
- Schema doc + `data/README.md`

## Test plan
- [x] `npx vitest run src/app/api/decision-graph/route.test.ts` (3 passed)
- [ ] Project a decision-log via MiscRepos `project_decision_graph.py` into `data/decision-graph.sqlite`
- [ ] Open `/decision-chain` with OG dev server

## Depends on
- MiscRepos: https://github.com/ManintheCrowds/MiscRepos/pull/47
- OpenHarness (docs): https://github.com/ManintheCrowds/OpenHarness/pull/4